### PR TITLE
remove py32 from tox.ini, keeping it in line with .travis.yml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py32,py33,py34
+envlist = py27,pypy,py33,py34
 
 [testenv]
 deps =


### PR DESCRIPTION
I noticed that Travis doesn't run any tests for Python 3.2, but tox does.  So I removed `py32` from tox's env list.