### PR TITLE
Fix some FIXMEs

### DIFF
--- a/automat/_core.py
+++ b/automat/_core.py
@@ -8,6 +8,8 @@ Perhaps something that could be replaced with or integrated into machinist.
 
 from itertools import chain
 
+_NO_STATE = "<no state>"
+
 
 class Automaton(object):
     """
@@ -18,10 +20,32 @@ class Automaton(object):
 
     def __init__(self):
         """
-        Initialize the set of transitions and final states.
+        Initialize the set of transitions and the initial state.
         """
-        self._initialStates = set()
+        self._initialState = _NO_STATE
         self._transitions = set()
+
+
+    @property
+    def initialState(self):
+        """
+        Return this automaton's initial state.
+        """
+        return self._initialState
+
+
+    @initialState.setter
+    def initialState(self, state):
+        """
+        Set this automaton's initial state.  Raises a ValueError if
+        this automaton already has an initial state.
+        """
+
+        if self._initialState is not _NO_STATE:
+            raise ValueError(
+                "initial state already set to {}".format(self._initialState))
+
+        self._initialState = state
 
 
     def addTransition(self, inState, inputSymbol, outState, outputSymbols):
@@ -38,13 +62,6 @@ class Automaton(object):
         All transitions.
         """
         return frozenset(self._transitions)
-
-
-    def addInitialState(self, state):
-        """
-        Add the given atom to the set of initial states.
-        """
-        self._initialStates.add(state)
 
 
     def inputAlphabet(self):
@@ -83,13 +100,6 @@ class Automaton(object):
         )
 
 
-    def initialStates(self):
-        """
-        
-        """
-        return frozenset(self._initialStates)
-
-
     def outputForInput(self, inState, inputSymbol):
         """
         A 2-tuple of (outState, outputSymbols) for inputSymbol.
@@ -121,6 +131,3 @@ class Transitioner(object):
                                                                  inputSymbol)
         self._state = outState
         return outputSymbols
-
-
-

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -62,8 +62,7 @@ def _transitionerFromInstance(oself, symbol, automaton):
     if transitioner is None:
         transitioner = Transitioner(
             automaton,
-            # FIXME: public API on Automaton for getting the initial state.
-            list(automaton._initialStates)[0],
+            automaton.initialState,
         )
         setattr(oself, symbol, transitioner)
     return transitioner
@@ -186,7 +185,7 @@ class MethodicalMachine(object):
                                     method=stateMethod,
                                     serialized=serialized)
             if initial:
-                self._automaton.addInitialState(state)
+                self._automaton.initialState = state
             return state
         return decorator
 
@@ -247,7 +246,7 @@ class MethodicalMachine(object):
     @_keywords_only
     def serializer(self):
         """
-        
+
         """
         def decorator(decoratee):
             @wraps(decoratee)
@@ -261,7 +260,7 @@ class MethodicalMachine(object):
     @_keywords_only
     def unserializer(self):
         """
-        
+
         """
         def decorator(decoratee):
             @wraps(decoratee)

--- a/automat/_test/test_core.py
+++ b/automat/_test/test_core.py
@@ -33,6 +33,22 @@ class CoreTests(TestCase):
                          ("ending", ["end"]))
         self.assertEqual(a.states(), set(["beginning", "ending"]))
 
+
+    def test_oneTransition_nonIterableOutputs(self):
+        """
+        L{Automaton.addTransition} raises a TypeError when given outputs
+        that aren't iterable and doesn't add any transitions.
+        """
+        a = Automaton()
+        nonIterableOutputs = 1
+        self.assertRaises(
+            TypeError,
+            a.addTransition,
+            "fromState", "viaSymbol", "toState", nonIterableOutputs)
+        self.assertFalse(a.inputAlphabet())
+        self.assertFalse(a.outputAlphabet())
+        self.assertFalse(a.states())
+        self.assertFalse(a.allTransitions())
+
 # FIXME: addTransition for transition that's been added before
-# FIXME: addTransition with a non-iterable for outputs
 # FIXME: public API for determining initial states

--- a/automat/_test/test_core.py
+++ b/automat/_test/test_core.py
@@ -50,5 +50,18 @@ class CoreTests(TestCase):
         self.assertFalse(a.states())
         self.assertFalse(a.allTransitions())
 
+
+    def test_initialState(self):
+        """
+        L{Automaton.initialState} is a descriptor that sets the initial
+        state if it's not yet set, and raises L{ValueError} if it is.
+
+        """
+        a = Automaton()
+        a.initialState = "a state"
+        self.assertEqual(a.initialState, "a state")
+        with self.assertRaises(ValueError):
+            a.initialState = "another state"
+
+
 # FIXME: addTransition for transition that's been added before
-# FIXME: public API for determining initial states

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -235,6 +235,24 @@ class MethodicalTests(TestCase):
             self.assertIn("outputThatDoesntMatch", str(cm.exception))
 
 
+    def test_multipleInitialStatesFailure(self):
+        """
+        A L{MethodicalMachine} can only have one initial state.
+        """
+
+        class WillFail(object):
+            m = MethodicalMachine()
+
+            @m.state(initial=True)
+            def firstInitialState(self):
+                "The first initial state -- this is OK."
+
+            with self.assertRaises(ValueError):
+                @m.state(initial=True)
+                def secondInitialState(self):
+                    "The second initial state -- results in a ValueError."
+
+
     def test_saveState(self):
         """
         L{MethodicalMachine.serializer} is a decorator that modifies its
@@ -336,7 +354,6 @@ class MethodicalTests(TestCase):
 
 
 
-# FIXME: error for more than one initial state
 # FIXME: error for wrong types on any call to _oneTransition
 # FIXME: better public API for .upon; maybe a context manager?
 # FIXME: when transitions are defined, validate that we can always get to

--- a/automat/_visualize.py
+++ b/automat/_visualize.py
@@ -27,7 +27,7 @@ def graphviz(automaton, inputAsString=repr,
     yield 'edge[fontname="Menlo"]\n'
 
     for state in automaton.states():
-        if state in automaton.initialStates():
+        if state is automaton.initialState:
             stateShape = "bold"
             fontName = "Menlo-Bold"
         else:


### PR DESCRIPTION
These were in `test_core`:

- test `addTransition` with outputs that aren't iterable
- add a public API for an `Automaton`'s initial state.  Note that a DFA can only have one initial state, so there's no longer a set of initial states, and you can only set the initial state once.