### PR TITLE
   Invalid transitions should raise NotImplementedError.

### DIFF
--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -4,7 +4,7 @@ from functools import wraps
 from itertools import count
 from inspect import getargspec
 
-from characteristic import attributes, Attribute
+from characteristic import with_repr, attributes, Attribute
 
 from ._core import Transitioner, Automaton
 from ._introspection import preserveName
@@ -25,7 +25,7 @@ def _keywords_only(f):
     return g
 
 
-
+@with_repr(['method'])
 @attributes(['machine', 'method', 'serialized'])
 class MethodicalState(object):
     """
@@ -69,7 +69,7 @@ def _transitionerFromInstance(oself, symbol, automaton):
     return transitioner
 
 
-
+@with_repr(['method'])
 @attributes(['automaton', 'method', 'symbol',
              Attribute('collectors', default_factory=dict)],
             apply_with_cmp=False)
@@ -90,13 +90,15 @@ class MethodicalInput(object):
         @wraps(self.method)
         def doInput(*args, **kwargs):
             self.method(oself, *args, **kwargs)
-            collector = self.collectors[transitioner._state]
+            previousState = transitioner._state
+            outputs = transitioner.transition(self)
+            collector = self.collectors[previousState]
             return collector(output(oself, *args, **kwargs)
-                             for output in transitioner.transition(self))
+                             for output in outputs)
         return doInput
 
 
-
+@with_repr(['method'])
 @attributes(['machine', 'method'])
 class MethodicalOutput(object):
     """
@@ -247,7 +249,7 @@ class MethodicalMachine(object):
     @_keywords_only
     def serializer(self):
         """
-        
+
         """
         def decorator(decoratee):
             @wraps(decoratee)
@@ -261,7 +263,7 @@ class MethodicalMachine(object):
     @_keywords_only
     def unserializer(self):
         """
-        
+
         """
         def decorator(decoratee):
             @wraps(decoratee)

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -235,6 +235,40 @@ class MethodicalTests(TestCase):
             self.assertIn("outputThatDoesntMatch", str(cm.exception))
 
 
+    def test_badTransitionForCurrentState(self):
+        """
+        Calling any input method that lacks a transition for the machine's
+        current state raises an informative C{NotImplementedError}.
+        """
+
+        class OnlyOnePath(object):
+            m = MethodicalMachine()
+            @m.state(initial=True)
+            def start(self):
+                "Start state."
+            @m.state()
+            def end(self):
+                "End state."
+            @m.input()
+            def advance(self):
+                "Move from start to end."
+            @m.input()
+            def deadEnd(self):
+                "A transition from nowhere to nowhere."
+            start.upon(advance, end, [])
+
+        machine = OnlyOnePath()
+        with self.assertRaises(NotImplementedError) as cm:
+            machine.deadEnd()
+        self.assertIn("deadEnd", str(cm.exception))
+        self.assertIn("start", str(cm.exception))
+        machine.advance()
+        with self.assertRaises(NotImplementedError) as cm:
+            machine.deadEnd()
+        self.assertIn("deadEnd", str(cm.exception))
+        self.assertIn("end", str(cm.exception))
+
+
     def test_saveState(self):
         """
         L{MethodicalMachine.serializer} is a decorator that modifies its


### PR DESCRIPTION
`automat._core.Automaton.outputForInput` implies that an invalid transition
should raise a `NotImplementedError`.  In practice, though,
`MethodicalMachine` may raise a `KeyError` because there's no
collector specified for a given state, because no transitions exist.

Reorder the code to always raise a `NotImplementedError`, add a test
to ensure this, and change the repr methods of various machine
components to succinctly describe themselves.