### PR TITLE
Invalid transitions now raise NoTransition instead of

### DIFF
--- a/automat/__init__.py
+++ b/automat/__init__.py
@@ -1,9 +1,8 @@
 # -*- test-case-name: automat -*-
 from ._methodical import MethodicalMachine
-# from ._core import Transitioner, Automaton
+from ._core import NoTransition
 
 __all__ = [
     'MethodicalMachine',
-    # 'Transitioner',
-    # 'Automaton',
+    'NoTransition',
 ]

--- a/automat/_core.py
+++ b/automat/_core.py
@@ -11,6 +11,24 @@ from itertools import chain
 _NO_STATE = "<no state>"
 
 
+class NoTransition(Exception):
+    """
+    A finite state machine in C{state} has no transition for C{symbol}.
+
+    @param state: the finite state machine's state at the time of the
+        illegal transition.
+
+    @param symbol: the input symbol for which no transition exists.
+    """
+
+    def __init__(self, state, symbol):
+        self.state = state
+        self.symbol = symbol
+        super(Exception, self).__init__(
+            "no transition for {} in {}".format(symbol, state)
+        )
+
+
 class Automaton(object):
     """
     A declaration of a finite state machine.
@@ -108,9 +126,7 @@ class Automaton(object):
              outState, outputSymbols) in self._transitions:
             if (inState, inputSymbol) == (anInState, anInputSymbol):
                 return (outState, list(outputSymbols))
-        raise NotImplementedError("no transition for {} in {}"
-                                  .format(inputSymbol, inState))
-
+        raise NoTransition(state=inState, symbol=inputSymbol)
 
 
 class Transitioner(object):

--- a/automat/_test/test_core.py
+++ b/automat/_test/test_core.py
@@ -1,5 +1,5 @@
 
-from .._core import Automaton
+from .._core import Automaton, NoTransition
 
 from unittest import TestCase
 
@@ -8,13 +8,32 @@ class CoreTests(TestCase):
     Tests for Automat's (currently private, implementation detail) core.
     """
 
+    def test_NoTransition(self):
+        """
+        A L{NoTransition} exception describes the state and input symbol
+        that caused it.
+        """
+        # NoTransition requires two arguments
+        with self.assertRaises(TypeError):
+            NoTransition()
+
+        state = "current-state"
+        symbol = "transitionless-symbol"
+        noTransitionException = NoTransition(state=state, symbol=symbol)
+
+        self.assertIs(noTransitionException.symbol, symbol)
+
+        self.assertIn(state, str(noTransitionException))
+        self.assertIn(symbol, str(noTransitionException))
+
+
     def test_noOutputForInput(self):
         """
-        L{Automaton.outputForInput} raises L{NotImplementedError} if no
+        L{Automaton.outputForInput} raises L{NoTransition} if no
         transition for that input is defined.
         """
         a = Automaton()
-        self.assertRaises(NotImplementedError, a.outputForInput,
+        self.assertRaises(NoTransition, a.outputForInput,
                           "no-state", "no-symbol")
 
 

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -6,7 +6,7 @@ Tests for the public interface of Automat.
 from functools import reduce
 from unittest import TestCase
 
-from .. import MethodicalMachine
+from .. import MethodicalMachine, NoTransition
 
 class MethodicalTests(TestCase):
     """
@@ -256,7 +256,7 @@ class MethodicalTests(TestCase):
     def test_badTransitionForCurrentState(self):
         """
         Calling any input method that lacks a transition for the machine's
-        current state raises an informative C{NotImplementedError}.
+        current state raises an informative C{NoTransition}.
         """
 
         class OnlyOnePath(object):
@@ -276,12 +276,12 @@ class MethodicalTests(TestCase):
             start.upon(advance, end, [])
 
         machine = OnlyOnePath()
-        with self.assertRaises(NotImplementedError) as cm:
+        with self.assertRaises(NoTransition) as cm:
             machine.deadEnd()
         self.assertIn("deadEnd", str(cm.exception))
         self.assertIn("start", str(cm.exception))
         machine.advance()
-        with self.assertRaises(NotImplementedError) as cm:
+        with self.assertRaises(NoTransition) as cm:
             machine.deadEnd()
         self.assertIn("deadEnd", str(cm.exception))
         self.assertIn("end", str(cm.exception))


### PR DESCRIPTION
NotImplementedError.

see discussion in #15.

@moshez - does this seem ok?  note that it doesn't inherit from `ValueError`.
@glyph - while writing this it occurred to me that `NoTransition` might be a better name than `InvalidStateForInput`.  what do you think?  also, i've never written epytext so look out for weirdness in the docstrings!