### PR TITLE
More robust graphviz dot generation

### DIFF
--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -279,19 +279,20 @@ class MethodicalMachine(object):
         return decorator
 
 
-    def graphviz(self):
+    def asDigraph(self):
         """
-        Visualize this state machine using graphviz.
+        Generate a C{graphviz.Digraph} that represents this machine's
+        states and transitions.
 
-        @return: an iterable of lines of graphviz-format data suitable for
-            feeding to C{dot} or C{neato} which visualizes the state machine
-            described by this L{MethodicalMachine}.
+        @return: C{graphviz.Digraph} object; for me information, please
+            see the documentation for
+            U{graphviz<https://graphviz.readthedocs.io/>}
+
         """
-        from ._visualize import graphviz
-        for line in graphviz(
-                self._automaton,
-                stateAsString=lambda state: state.method.__name__,
-                inputAsString=lambda input: input.method.__name__,
-                outputAsString=lambda output: output.method.__name__,
-        ):
-            yield line
+        from ._visualize import makeDigraph
+        return makeDigraph(
+            self._automaton,
+            stateAsString=lambda state: state.method.__name__,
+            inputAsString=lambda input: input.method.__name__,
+            outputAsString=lambda output: output.method.__name__,
+        )

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -281,10 +281,10 @@ class MethodicalMachine(object):
 
     def asDigraph(self):
         """
-        Generate a C{graphviz.Digraph} that represents this machine's
+        Generate a L{graphviz.Digraph} that represents this machine's
         states and transitions.
 
-        @return: C{graphviz.Digraph} object; for me information, please
+        @return: L{graphviz.Digraph} object; for more information, please
             see the documentation for
             U{graphviz<https://graphviz.readthedocs.io/>}
 

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -256,7 +256,7 @@ class MethodicalTests(TestCase):
     def test_badTransitionForCurrentState(self):
         """
         Calling any input method that lacks a transition for the machine's
-        current state raises an informative C{NoTransition}.
+        current state raises an informative L{NoTransition}.
         """
 
         class OnlyOnePath(object):

--- a/automat/_test/test_visualize.py
+++ b/automat/_test/test_visualize.py
@@ -8,19 +8,16 @@ from characteristic import attributes
 
 from .._methodical import MethodicalMachine
 
-from .._visualize import elementMaker, tableMaker
-
 
 def isGraphvizModuleInstalled():
     """
     Is the graphviz Python module installed?
     """
     try:
-        import graphviz
+        __import__("graphviz")
     except ImportError:
         return False
     else:
-        del graphviz
         return True
 
 
@@ -62,10 +59,15 @@ def sampleMachine():
     return mm
 
 
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
 class ElementMakerTests(TestCase):
     """
     Tests that ensure elementMaker generates correct HTML.
     """
+
+    def setUp(self):
+        from .._visualize import elementMaker
+        self.elementMaker = elementMaker
 
     def test_sortsAttrs(self):
         """
@@ -73,10 +75,10 @@ class ElementMakerTests(TestCase):
         """
         expected = r'<div a="1" b="2" c="3"></div>'
         self.assertEqual(expected,
-                         elementMaker("div",
-                                      b='2',
-                                      a='1',
-                                      c='3'))
+                         self.elementMaker("div",
+                                           b='2',
+                                           a='1',
+                                           c='3'))
 
     def test_quotesAttrs(self):
         """
@@ -84,17 +86,17 @@ class ElementMakerTests(TestCase):
         """
         expected = r'<div a="1" b="a \" quote" c="a string"></div>'
         self.assertEqual(expected,
-                         elementMaker("div",
-                                      b='a " quote',
-                                      a=1,
-                                      c="a string"))
+                         self.elementMaker("div",
+                                           b='a " quote',
+                                           a=1,
+                                           c="a string"))
 
     def test_noAttrs(self):
         """
         L{elementMaker} should render an element with no attributes.
         """
         expected = r'<div ></div>'
-        self.assertEqual(expected, elementMaker("div"))
+        self.assertEqual(expected, self.elementMaker("div"))
 
 
 @attributes(['name', 'children', 'attrs'])
@@ -124,6 +126,7 @@ def isLeaf(element):
     return not isinstance(element, HTMLElement)
 
 
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
 class TableMakerTests(TestCase):
     """
     Tests that ensure tableMaker generates correctly structured tables.
@@ -133,6 +136,8 @@ class TableMakerTests(TestCase):
         return HTMLElement(name=name, children=children, attrs=attrs)
 
     def setUp(self):
+        from .._visualize import tableMaker
+
         self.inputLabel = "input label"
         self.port = "the port"
         self.tableMaker = functools.partial(tableMaker,

--- a/automat/_test/test_visualize.py
+++ b/automat/_test/test_visualize.py
@@ -7,10 +7,25 @@ from unittest import TestCase, skipIf
 
 from .._methodical import MethodicalMachine
 
+
+def isGraphvizModuleInstalled():
+    """
+    Is the graphviz Python module installed?
+    """
+    try:
+        import graphviz
+    except ImportError:
+        return False
+    else:
+        del graphviz
+        return True
+
+
 def isGraphvizInstalled():
     """
-    Is graphviz installed?
+    Are the graphviz tools installed?
     """
+
     r, w = os.pipe()
     os.close(w)
     try:
@@ -45,7 +60,8 @@ def sampleMachine():
 
 
 
-@skipIf(not isGraphvizInstalled(), "Graphviz is not installed.")
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
+@skipIf(not isGraphvizInstalled(), "Graphviz tools are not installed.")
 class IntegrationTests(TestCase):
     """
     Tests which make sure Graphviz can understand the output produced by
@@ -58,11 +74,12 @@ class IntegrationTests(TestCase):
         """
         p = subprocess.Popen("dot", stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE)
-        out, err = p.communicate("".join(sampleMachine().graphviz())
+        out, err = p.communicate("".join(sampleMachine().asDigraph())
                                  .encode("utf-8"))
         self.assertEqual(p.returncode, 0)
 
 
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
 class SpotChecks(TestCase):
     """
     Tests to make sure that the output contains salient features of the machine
@@ -74,7 +91,7 @@ class SpotChecks(TestCase):
         The output of L{graphviz} should contain the names of the states,
         inputs, outputs in the state machine.
         """
-        gvout = "".join(sampleMachine().graphviz())
+        gvout = "".join(sampleMachine().asDigraph())
         self.assertIn("begin", gvout)
         self.assertIn("end", gvout)
         self.assertIn("go", gvout)

--- a/automat/_visualize.py
+++ b/automat/_visualize.py
@@ -58,8 +58,7 @@ def makeDigraph(automaton, inputAsString=repr,
                 outputAsString=repr,
                 stateAsString=repr):
     """
-    Produce a C{graphviz.Digraph} object from an automaton.
-
+    Produce a L{graphviz.Digraph} object from an automaton.
     """
     digraph = graphviz.Digraph(graph_attr={'pack': 'true',
                                            'dpi': '100'},

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
         "characteristic",
         "six",
     ],
+    extras_require={
+        'visualize': ['graphviz>=0.4.9']
+    },
     include_package_data=True,
     license="MIT",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,pypy,py33,py34
 
 [testenv]
 deps =
+    graphviz>=0.4.9
     coverage
     pytest
 


### PR DESCRIPTION
This PR consists of two commits:

1) The first switches the visualization code over to [graphviz](https://graphviz.readthedocs.io).  This lays the ground work for later features, such as automatic previewing with an appropriate image viewer.  But there are no such feature additions or bug fixes in this commit.  Note that this dependency appears under an extra (`visualize`).

2) The second replaces HTML table generation via string-interpolation with an [ElementMaker/E-Factory](http://lxml.de/tutorial.html#the-e-factory) like API.  In doing so, it addresses two issues in the previous table generation code that caused dot to incompletely render the graph.  Those issues:

1) `port` cannot be on a `<table>` element. It must be on a `<td>`;
2) a `tr`'s `colspan` cannot be 0; instead, it must be absent.

The element maker approach may be too complicated.  In its defense, however, I was able to write a series of regression tests that cover these issues.  If that doesn't sway you, I'm happy to push a new commit that patches the previous string interpolation code.