### PR TITLE
Visualizer tool

### DIFF
--- a/automat/__main__.py
+++ b/automat/__main__.py
@@ -1,0 +1,3 @@
+from ._visualize import tool
+
+tool()

--- a/automat/_discover.py
+++ b/automat/_discover.py
@@ -1,0 +1,144 @@
+import collections
+import inspect
+from automat import MethodicalMachine
+from twisted.python.modules import PythonModule, getModule
+
+
+def isOriginalLocation(attr):
+    """
+    Attempt to discover if this appearance of a PythonAttribute
+    representing a class refers to the module where that class was
+    defined.
+    """
+    sourceModule = inspect.getmodule(attr.load())
+    if sourceModule is None:
+        return False
+
+    currentModule = attr
+    while not isinstance(currentModule, PythonModule):
+        currentModule = currentModule.onObject
+
+    return currentModule.name == sourceModule.__name__
+
+
+def findMachinesViaWrapper(within):
+    """
+    Recursively yield L{MethodicalMachine}s and their FQPNs within a
+    L{PythonModule} or a L{twisted.python.modules.PythonAttribute}
+    wrapper object.
+
+    Note that L{PythonModule}s may refer to packages, as well.
+
+    The discovery heuristic considers L{MethodicalMachine} instances
+    that are module-level attributes or class-level attributes
+    accessible from module scope.  Machines inside nested classes will
+    be discovered, but those returned from functions or methods will not be.
+
+    @type within: L{PythonModule} or L{twisted.python.modules.PythonAttribute}
+    @param within: Where to start the search.
+
+    @return: a generator which yields FQPN, L{MethodicalMachine} pairs.
+    """
+    queue = collections.deque([within])
+    visited = set()
+
+    while queue:
+        attr = queue.pop()
+        value = attr.load()
+
+        if isinstance(value, MethodicalMachine) and value not in visited:
+            visited.add(value)
+            yield attr.name, value
+        elif (inspect.isclass(value) and isOriginalLocation(attr) and
+              value not in visited):
+            visited.add(value)
+            queue.extendleft(attr.iterAttributes())
+        elif isinstance(attr, PythonModule) and value not in visited:
+            visited.add(value)
+            queue.extendleft(attr.iterAttributes())
+            queue.extendleft(attr.iterModules())
+
+
+class InvalidFQPN(Exception):
+    """
+    The given FQPN was not a dot-separated list of Python objects.
+    """
+
+
+class NoModule(InvalidFQPN):
+    """
+    A prefix of the FQPN was not an importable module or package.
+    """
+
+
+class NoObject(InvalidFQPN):
+    """
+    A suffix of the FQPN was not an accessible object
+    """
+
+
+def wrapFQPN(fqpn):
+    """
+    Given an FQPN, retrieve the object via the global Python module
+    namespace and wrap it with a L{PythonModule} or a
+    L{twisted.python.modules.PythonAttribute}.
+    """
+    # largely cribbed from t.p.reflect.namedAny
+
+    if not fqpn:
+        raise InvalidFQPN("FQPN was empty")
+
+    components = collections.deque(fqpn.split('.'))
+
+    if '' in components:
+        raise InvalidFQPN(
+            "name must be a string giving a '.'-separated list of Python "
+            "identifiers, not %r" % (fqpn,))
+
+    component = components.popleft()
+    try:
+        module = getModule(component)
+    except KeyError:
+        raise NoModule(component)
+
+    # find the bottom-most module
+    while components:
+        component = components.popleft()
+        try:
+            module = module[component]
+        except KeyError:
+            components.appendleft(component)
+            break
+        else:
+            module.load()
+    else:
+        return module
+
+    # find the bottom-most attribute
+    attribute = module
+    for component in components:
+        try:
+            attribute = next(child for child in attribute.iterAttributes()
+                             if child.name.rsplit('.', 1)[-1] == component)
+        except StopIteration:
+            raise NoObject('{}.{}'.format(attribute.name, component))
+
+    return attribute
+
+
+def findMachines(fqpn):
+    """
+    Recursively yield L{MethodicalMachine}s and their FQPNs in and
+    under the a Python object specified by an FQPN.
+
+    The discovery heuristic considers L{MethodicalMachine} instances
+    that are module-level attributes or class-level attributes
+    accessible from module scope.  Machines inside nested classes will
+    be discovered, but those returned from functions or methods will not be.
+
+    @type within: an FQPN
+    @param within: Where to start the search.
+
+    @return: a generator which yields FQPN, L{MethodicalMachine} pairs.
+    """
+    return findMachinesViaWrapper(wrapFQPN(fqpn))

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -279,19 +279,20 @@ class MethodicalMachine(object):
         return decorator
 
 
-    def graphviz(self):
+    def asDigraph(self):
         """
-        Visualize this state machine using graphviz.
+        Generate a C{graphviz.Digraph} that represents this machine's
+        states and transitions.
 
-        @return: an iterable of lines of graphviz-format data suitable for
-            feeding to C{dot} or C{neato} which visualizes the state machine
-            described by this L{MethodicalMachine}.
+        @return: C{graphviz.Digraph} object; for me information, please
+            see the documentation for
+            U{graphviz<https://graphviz.readthedocs.io/>}
+
         """
-        from ._visualize import graphviz
-        for line in graphviz(
-                self._automaton,
-                stateAsString=lambda state: state.method.__name__,
-                inputAsString=lambda input: input.method.__name__,
-                outputAsString=lambda output: output.method.__name__,
-        ):
-            yield line
+        from ._visualize import makeDigraph
+        return makeDigraph(
+            self._automaton,
+            stateAsString=lambda state: state.method.__name__,
+            inputAsString=lambda input: input.method.__name__,
+            outputAsString=lambda output: output.method.__name__,
+        )

--- a/automat/_test/test_discover.py
+++ b/automat/_test/test_discover.py
@@ -1,0 +1,596 @@
+import operator
+import os
+import shutil
+import sys
+import textwrap
+import tempfile
+from unittest import skipIf, TestCase
+
+import six
+
+from .._discover import (isOriginalLocation,
+                         findMachinesViaWrapper,
+                         wrapFQPN,
+                         InvalidFQPN,
+                         NoModule,
+                         NoObject,
+                         findMachines)
+
+
+def isTwistedInstalled():
+    try:
+        __import__('twisted')
+    except ImportError:
+        return False
+    else:
+        return True
+
+
+class _WritesPythonModules(TestCase):
+    """
+    A helper that allows writing Python modules and packages as test fixtures.
+    """
+
+    def setUp(self):
+        super(_WritesPythonModules, self).setUp()
+
+        from twisted.python.modules import getModule, PythonPath
+        from twisted.python.filepath import FilePath
+
+        self.getModule = getModule
+        self.PythonPath = PythonPath
+        self.FilePath = FilePath
+
+        self.originalSysModules = set(sys.modules.keys())
+        self.savedSysPath = sys.path[:]
+
+        self.pathDir = tempfile.mkdtemp()
+        self.makeImportable(self.pathDir)
+
+    def tearDown(self):
+        super(_WritesPythonModules, self).tearDown()
+
+        sys.path[:] = self.savedSysPath
+        modulesToDelete = six.viewkeys(sys.modules) - self.originalSysModules
+        for module in modulesToDelete:
+            del sys.modules[module]
+
+        shutil.rmtree(self.pathDir)
+
+    def makeImportable(self, path):
+        sys.path.append(path)
+
+    def writeSourceInto(self, source, path, moduleName):
+        directory = self.FilePath(path)
+
+        module = directory.child(moduleName)
+        # FilePath always opens a file in binary mode - but that will
+        # break on Python 3
+        with open(module.path, 'w') as f:
+            f.write(textwrap.dedent(source))
+
+        return self.PythonPath([directory.path])
+
+    def makeModule(self, source, path, moduleName):
+        pythonModuleName, _ = os.path.splitext(moduleName)
+        return self.writeSourceInto(source, path, moduleName)[pythonModuleName]
+
+    def attributesAsDict(self, hasIterAttributes):
+        return {attr.name: attr for attr in hasIterAttributes.iterAttributes()}
+
+    def loadModuleAsDict(self, module):
+        module.load()
+        return self.attributesAsDict(module)
+
+    def makeModuleAsDict(self, source, path, name):
+        return self.loadModuleAsDict(self.makeModule(source, path, name))
+
+
+@skipIf(not isTwistedInstalled(), "Twisted is not installed.")
+class OriginalLocationTests(_WritesPythonModules):
+    """
+    Tests that L{isOriginalLocation} detects when a
+    L{PythonAttribute}'s FQPN refers to an object inside the module
+    where it was defined.
+
+    For example: A L{twisted.python.modules.PythonAttribute} with a
+    name of 'foo.bar' that refers to a 'bar' object defined in module
+    'baz' does *not* refer to bar's original location, while a
+    L{PythonAttribute} with a name of 'baz.bar' does.
+
+    """
+    def test_failsWithNoModule(self):
+        """
+        L{isOriginalLocation} returns False when the attribute refers to an
+        object whose source module cannot be determined.
+        """
+        source = """\
+        class Fake(object):
+            pass
+        hasEmptyModule = Fake()
+        hasEmptyModule.__module__ = None
+        """
+
+        moduleDict = self.makeModuleAsDict(source,
+                                           self.pathDir,
+                                           'empty_module_attr.py')
+
+        self.assertFalse(isOriginalLocation(
+            moduleDict['empty_module_attr.hasEmptyModule']))
+
+    def test_failsWithDifferentModule(self):
+        """
+        L{isOriginalLocation} returns False when the attribute refers to
+        an object outside of the module where that object was defined.
+        """
+        originalSource = """\
+        class ImportThisClass(object):
+            pass
+        importThisObject = ImportThisClass()
+        importThisNestingObject = ImportThisClass()
+        importThisNestingObject.nestedObject = ImportThisClass()
+        """
+
+        importingSource = """\
+        from original import (ImportThisClass,
+                              importThisObject,
+                              importThisNestingObject)
+        """
+
+        self.makeModule(originalSource, self.pathDir, 'original.py')
+        importingDict = self.makeModuleAsDict(importingSource,
+                                              self.pathDir,
+                                              'importing.py')
+        self.assertFalse(
+            isOriginalLocation(importingDict['importing.ImportThisClass']))
+        self.assertFalse(
+            isOriginalLocation(importingDict['importing.importThisObject']))
+
+        nestingObject = importingDict['importing.importThisNestingObject']
+        nestingObjectDict = self.attributesAsDict(nestingObject)
+        nestedObject = nestingObjectDict[
+            'importing.importThisNestingObject.nestedObject']
+
+        self.assertFalse(isOriginalLocation(nestedObject))
+
+    def test_succeedsWithSameModule(self):
+        """
+        L{isOriginalLocation} returns True when the attribute refers to an
+        object inside the module where that object was defined.
+        """
+        mSource = textwrap.dedent("""
+        class ThisClassWasDefinedHere(object):
+            pass
+        anObject = ThisClassWasDefinedHere()
+        aNestingObject = ThisClassWasDefinedHere()
+        aNestingObject.nestedObject = ThisClassWasDefinedHere()
+        """)
+        mDict = self.makeModuleAsDict(mSource, self.pathDir, 'm.py')
+        self.assertTrue(isOriginalLocation(mDict['m.ThisClassWasDefinedHere']))
+        self.assertTrue(isOriginalLocation(mDict['m.aNestingObject']))
+
+        nestingObject = mDict['m.aNestingObject']
+        nestingObjectDict = self.attributesAsDict(nestingObject)
+        nestedObject = nestingObjectDict['m.aNestingObject.nestedObject']
+
+        self.assertTrue(isOriginalLocation(nestedObject))
+
+
+@skipIf(not isTwistedInstalled(), "Twisted is not installed.")
+class FindMachinesViaWrapperTests(_WritesPythonModules):
+    """
+    L{findMachinesViaWrapper} should recursively yield FQPN,
+    L{MethodicalMachine} pairs in and under a given
+    L{twisted.python.modules.PythonModule} or
+    L{twisted.python.modules.PythonAttribute}.
+    """
+    TEST_MODULE_SOURCE = """
+    from automat import MethodicalMachine
+
+
+    class PythonClass(object):
+        _classMachine = MethodicalMachine()
+
+        class NestedClass(object):
+            _nestedClassMachine = MethodicalMachine()
+
+        ignoredAttribute = "I am ignored."
+
+        def ignoredMethod(self):
+            "I am also ignored."
+
+    rootLevelMachine = MethodicalMachine()
+    ignoredPythonObject = PythonClass()
+    anotherIgnoredPythonObject = "I am ignored."
+    """
+
+    def test_yieldsMachine(self):
+        """
+        When given a L{twisted.python.modules.PythonAttribute} that refers
+        directly to a L{MethodicalMachine}, L{findMachinesViaWrapper}
+        yields that machine with the correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        rootMachine = MethodicalMachine()
+        """
+
+        moduleDict = self.makeModuleAsDict(source, self.pathDir, 'root.py')
+        rootMachine = moduleDict['root.rootMachine']
+        self.assertIn(('root.rootMachine', rootMachine.load()),
+                      list(findMachinesViaWrapper(rootMachine)))
+
+    def test_yieldsMachineInClass(self):
+        """
+        When given a L{twisted.python.modules.PythonAttribute} that refers
+        to a class that contains L{MethodicalMachine} as a class
+        variable, L{findMachinesViaWrapper} yields that machine with
+        the correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        class PythonClass(object):
+            _classMachine = MethodicalMachine()
+        """
+        moduleDict = self.makeModuleAsDict(source, self.pathDir, 'clsmod.py')
+        PythonClass = moduleDict['clsmod.PythonClass']
+        self.assertIn(('clsmod.PythonClass._classMachine',
+                       PythonClass.load()._classMachine),
+                      list(findMachinesViaWrapper(PythonClass)))
+
+    def test_yieldsMachineInNestedClass(self):
+        """
+        When given a L{twisted.python.modules.PythonAttribute} that refers
+        to a nested class that contains L{MethodicalMachine} as a class
+        variable, L{findMachinesViaWrapper} yields that machine with
+        the correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        class PythonClass(object):
+            class NestedClass(object):
+                _classMachine = MethodicalMachine()
+        """
+        moduleDict = self.makeModuleAsDict(source,
+                                           self.pathDir,
+                                           'nestedcls.py')
+
+        PythonClass = moduleDict['nestedcls.PythonClass']
+        self.assertIn(('nestedcls.PythonClass.NestedClass._classMachine',
+                       PythonClass.load().NestedClass._classMachine),
+                      list(findMachinesViaWrapper(PythonClass)))
+
+    def test_yieldsMachineInModule(self):
+        """
+        When given a L{twisted.python.modules.PythonModule} that refers to
+        a module that contains a L{MethodicalMachine},
+        L{findMachinesViaWrapper} yields that machine with the
+        correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        rootMachine = MethodicalMachine()
+        """
+        module = self.makeModule(source, self.pathDir, 'root.py')
+        rootMachine = self.loadModuleAsDict(module)['root.rootMachine'].load()
+        self.assertIn(('root.rootMachine', rootMachine),
+                      list(findMachinesViaWrapper(module)))
+
+    def test_yieldsMachineInClassInModule(self):
+        """
+        When given a L{twisted.python.modules.PythonModule} that refers to
+        the original module of a class containing a
+        L{MethodicalMachine}, L{findMachinesViaWrapper} yields that
+        machine with the correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        class PythonClass(object):
+            _classMachine = MethodicalMachine()
+        """
+        module = self.makeModule(source, self.pathDir, 'clsmod.py')
+        PythonClass = self.loadModuleAsDict(
+            module)['clsmod.PythonClass'].load()
+        self.assertIn(('clsmod.PythonClass._classMachine',
+                       PythonClass._classMachine),
+                      list(findMachinesViaWrapper(module)))
+
+    def test_yieldsMachineInNestedClassInModule(self):
+        """
+        When given a L{twisted.python.modules.PythonModule} that refers to
+        the original module of a nested class containing a
+        L{MethodicalMachine}, L{findMachinesViaWrapper} yields that
+        machine with the correct FQPN.
+        """
+        source = """\
+        from automat import MethodicalMachine
+
+        class PythonClass(object):
+            class NestedClass(object):
+                _classMachine = MethodicalMachine()
+        """
+        module = self.makeModule(source, self.pathDir, 'nestedcls.py')
+        PythonClass = self.loadModuleAsDict(
+            module)['nestedcls.PythonClass'].load()
+
+        self.assertIn(('nestedcls.PythonClass.NestedClass._classMachine',
+                       PythonClass.NestedClass._classMachine),
+                      list(findMachinesViaWrapper(module)))
+
+    def test_ignoresImportedClass(self):
+        """
+        When given L{twisted.python.modules.PythonAttribute} that refers
+        to a class imported from another module, any
+        L{MethodicalMachine}s on that class are ignored.
+
+        This behavior ensures that a machine is only discovered on a
+        class when visiting the module where that class was defined.
+        """
+        originalSource = """
+        from automat import MethodicalMachine
+
+        class PythonClass(object):
+            _classMachine = MethodicalMachine()
+        """
+
+        importingSource = """
+        from original import PythonClass
+        """
+
+        self.makeModule(originalSource, self.pathDir, 'original.py')
+        importingModule = self.makeModule(importingSource,
+                                          self.pathDir,
+                                          'importing.py')
+
+        self.assertFalse(list(findMachinesViaWrapper(importingModule)))
+
+    def test_descendsIntoPackages(self):
+        """
+        L{findMachinesViaWrapper} descends into packages to discover
+        machines.
+        """
+        pythonPath = self.PythonPath([self.pathDir])
+        package = self.FilePath(self.pathDir).child("test_package")
+        package.makedirs()
+        package.child('__init__.py').touch()
+
+        source = """
+        from automat import MethodicalMachine
+
+
+        class PythonClass(object):
+            _classMachine = MethodicalMachine()
+
+
+        rootMachine = MethodicalMachine()
+        """
+        self.makeModule(source, package.path, 'module.py')
+
+        test_package = pythonPath['test_package']
+        machines = sorted(findMachinesViaWrapper(test_package),
+                          key=operator.itemgetter(0))
+
+        moduleDict = self.loadModuleAsDict(test_package['module'])
+        rootMachine = moduleDict['test_package.module.rootMachine'].load()
+        PythonClass = moduleDict['test_package.module.PythonClass'].load()
+
+        expectedMachines = sorted(
+            [('test_package.module.rootMachine',
+              rootMachine),
+             ('test_package.module.PythonClass._classMachine',
+              PythonClass._classMachine)], key=operator.itemgetter(0))
+
+        self.assertEqual(expectedMachines, machines)
+
+    def test_infiniteLoop(self):
+        """
+        L{findMachinesViaWrapper} ignores infinite loops.
+
+        Note this test can't fail - it can only run forever...
+        """
+        source = """
+        class InfiniteLoop(object):
+            pass
+
+        InfiniteLoop.loop = InfiniteLoop
+        """
+        module = self.makeModule(source, self.pathDir, 'loop.py')
+        self.assertFalse(list(findMachinesViaWrapper(module)))
+
+
+@skipIf(not isTwistedInstalled(), "Twisted is not installed.")
+class WrapFQPNTests(TestCase):
+    """
+    Tests that ensure L{wrapFQPN} loads the correct
+    L{twisted.python.modules.PythonModule} or
+    L{twisted.python.modules.PythonAttribute} for a given FQPN.
+    """
+
+    def setUp(self):
+        from twisted.python.modules import PythonModule, PythonAttribute
+        self.PythonModule = PythonModule
+        self.PythonAttribute = PythonAttribute
+
+    def assertModuleWrapperRefersTo(self, moduleWrapper, module):
+        """
+        Assert that a L{twisted.python.modules.PythonModule} refers to an
+        actual Python module.
+
+        """
+        self.assertIsInstance(moduleWrapper, self.PythonModule)
+        self.assertEqual(moduleWrapper.name, module.__name__)
+        self.assertIs(moduleWrapper.load(), module)
+
+    def assertAttributeWrapperRefersTo(self, attributeWrapper, fqpn, obj):
+        """
+        Assert that a L{twisted.python.modules.PythonAttribute} refers to a
+        particular Python object.
+        """
+        self.assertIsInstance(attributeWrapper, self.PythonAttribute)
+        self.assertEqual(attributeWrapper.name, fqpn)
+        self.assertIs(attributeWrapper.load(), obj)
+
+    def test_failsWithEmptyFQPN(self):
+        """
+        L{wrapFQPN} raises L{InvalidFQPN} when given an empty string.
+        """
+        with self.assertRaises(InvalidFQPN):
+            wrapFQPN('')
+
+    def test_failsWithIncorrectDotting(self):
+        """"
+        L{wrapFQPN} raises L{InvalidFQPN} when given an
+        incorrectly-dotted FQPN
+        """
+        for bad in ('.fails', 'fails.', 'this..fails'):
+            with self.assertRaises(InvalidFQPN):
+                wrapFQPN(bad)
+
+    def test_singleModule(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonModule}
+        referring to the single module a dotless FQPN describes.
+        """
+        import os
+
+        moduleWrapper = wrapFQPN('os')
+
+        self.assertIsInstance(moduleWrapper, self.PythonModule)
+        self.assertIs(moduleWrapper.load(), os)
+
+    def test_failsWithMissingSingleModuleOrPackage(self):
+        """
+        L{wrapFQPN} raises L{NoModule} when given a dotless FQPN that does
+        not refer to a module or package.
+        """
+        with self.assertRaises(NoModule):
+            wrapFQPN("this is not an acceptable name!")
+
+    def test_singlePackage(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonModule}
+        referring to the single package a dotless FQPN describes.
+        """
+        import xml
+        self.assertModuleWrapperRefersTo(wrapFQPN('xml'), xml)
+
+    def test_multiplePackages(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonModule}
+        referring to the deepest module described by dotted FQPN.
+        """
+        import xml.etree
+        self.assertModuleWrapperRefersTo(wrapFQPN('xml.etree'), xml.etree)
+
+    def test_multiplePackagesFinalModule(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonModule}
+        referring to the deepest module described by dotted FQPN.
+        """
+        import xml.etree.ElementTree
+        self.assertModuleWrapperRefersTo(
+            wrapFQPN('xml.etree.ElementTree'), xml.etree.ElementTree)
+
+    def test_singleModuleObject(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonAttribute}
+        referring to the deepest object an FQPN with a depth of one module.
+        """
+        import os
+        self.assertAttributeWrapperRefersTo(
+            wrapFQPN('os.path'), 'os.path', os.path)
+
+    def test_multiplePackagesObject(self):
+        """
+        L{wrapFQPN} returns a L{twisted.python.modules.PythonAttribute}
+        referring to the deepest object an FQPN that descends through
+        several packages.
+        """
+        import xml.etree.ElementTree
+        import automat
+
+        for fqpn, obj in [('xml.etree.ElementTree.fromstring',
+                           xml.etree.ElementTree.fromstring),
+                          ('automat.MethodicalMachine.__doc__',
+                           automat.MethodicalMachine.__doc__)]:
+            self.assertAttributeWrapperRefersTo(
+                wrapFQPN(fqpn), fqpn, obj)
+
+    def test_failsWithMultiplePackagesMissingModuleOrPackage(self):
+        """
+        L{wrapFQPN} raises L{NoObject} when given an FQPN that contains a
+        missing attribute.
+        """
+        for bad in ('xml.etree.nope!',
+                    'xml.etree.nope!.but.the.rest.is.believable'):
+            with self.assertRaises(NoObject):
+                wrapFQPN(bad)
+
+
+@skipIf(not isTwistedInstalled(), "Twisted is not installed.")
+class FindMachinesIntegrationTests(_WritesPythonModules):
+    """
+    Integration tests to check that L{findMachines} yields all
+    machines discoverable at or below an FQPN.
+    """
+
+    SOURCE = """
+    from automat import MethodicalMachine
+
+    class PythonClass(object):
+        _machine = MethodicalMachine()
+        ignored = "i am ignored"
+
+    rootLevel = MethodicalMachine()
+
+    ignored = "i am ignored"
+    """
+
+    def setUp(self):
+        super(FindMachinesIntegrationTests, self).setUp()
+        packageDir = self.FilePath(self.pathDir).child("test_package")
+        packageDir.makedirs()
+        self.pythonPath = self.PythonPath([self.pathDir])
+        self.writeSourceInto(self.SOURCE, packageDir.path, '__init__.py')
+
+        subPackageDir = packageDir.child('subpackage')
+        subPackageDir.makedirs()
+        subPackageDir.child('__init__.py').touch()
+
+        self.makeModule(self.SOURCE, subPackageDir.path, 'module.py')
+
+        self.packageDict = self.loadModuleAsDict(
+            self.pythonPath['test_package'])
+        self.moduleDict = self.loadModuleAsDict(
+            self.pythonPath['test_package']['subpackage']['module'])
+
+    def test_discoverAll(self):
+        """
+        Given a top-level package FQPN, L{findMachines} discovers all
+        L{MethodicalMachine} instances in and below it.
+        """
+        machines = sorted(findMachines('test_package'),
+                          key=operator.itemgetter(0))
+
+        tpRootLevel = self.packageDict['test_package.rootLevel'].load()
+        tpPythonClass = self.packageDict['test_package.PythonClass'].load()
+
+        mRLAttr = self.moduleDict['test_package.subpackage.module.rootLevel']
+        mRootLevel = mRLAttr.load()
+        mPCAttr = self.moduleDict['test_package.subpackage.module.PythonClass']
+        mPythonClass = mPCAttr.load()
+
+        expectedMachines = sorted(
+            [('test_package.rootLevel', tpRootLevel),
+             ('test_package.PythonClass._machine', tpPythonClass._machine),
+             ('test_package.subpackage.module.rootLevel', mRootLevel),
+             ('test_package.subpackage.module.PythonClass._machine',
+              mPythonClass._machine)],
+            key=operator.itemgetter(0))
+
+        self.assertEqual(expectedMachines, machines)

--- a/automat/_test/test_discover.py
+++ b/automat/_test/test_discover.py
@@ -20,7 +20,7 @@ def isTwistedInstalled():
 
 class _WritesPythonModules(TestCase):
     """
-    A helper that allows writing Python modules and packages as test fixtures.
+    A helper that enables generating Python module test fixtures.
     """
 
     def setUp(self):
@@ -179,7 +179,7 @@ class OriginalLocationTests(_WritesPythonModules):
 @skipIf(not isTwistedInstalled(), "Twisted is not installed.")
 class FindMachinesViaWrapperTests(_WritesPythonModules):
     """
-    L{findMachinesViaWrapper} should recursively yield FQPN,
+    L{findMachinesViaWrapper} recursively yields FQPN,
     L{MethodicalMachine} pairs in and under a given
     L{twisted.python.modules.PythonModule} or
     L{twisted.python.modules.PythonAttribute}.
@@ -213,7 +213,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
         """
         When given a L{twisted.python.modules.PythonAttribute} that refers
         directly to a L{MethodicalMachine}, L{findMachinesViaWrapper}
-        yields that machine with the correct FQPN.
+        yields that machine and its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -229,9 +229,9 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
     def test_yieldsMachineInClass(self):
         """
         When given a L{twisted.python.modules.PythonAttribute} that refers
-        to a class that contains L{MethodicalMachine} as a class
-        variable, L{findMachinesViaWrapper} yields that machine with
-        the correct FQPN.
+        to a class that contains a L{MethodicalMachine} as a class
+        variable, L{findMachinesViaWrapper} yields that machine and
+        its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -248,9 +248,9 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
     def test_yieldsMachineInNestedClass(self):
         """
         When given a L{twisted.python.modules.PythonAttribute} that refers
-        to a nested class that contains L{MethodicalMachine} as a class
-        variable, L{findMachinesViaWrapper} yields that machine with
-        the correct FQPN.
+        to a nested class that contains a L{MethodicalMachine} as a
+        class variable, L{findMachinesViaWrapper} yields that machine
+        and its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -272,8 +272,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
         """
         When given a L{twisted.python.modules.PythonModule} that refers to
         a module that contains a L{MethodicalMachine},
-        L{findMachinesViaWrapper} yields that machine with the
-        correct FQPN.
+        L{findMachinesViaWrapper} yields that machine and its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -290,7 +289,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
         When given a L{twisted.python.modules.PythonModule} that refers to
         the original module of a class containing a
         L{MethodicalMachine}, L{findMachinesViaWrapper} yields that
-        machine with the correct FQPN.
+        machine and its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -310,7 +309,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
         When given a L{twisted.python.modules.PythonModule} that refers to
         the original module of a nested class containing a
         L{MethodicalMachine}, L{findMachinesViaWrapper} yields that
-        machine with the correct FQPN.
+        machine and its FQPN.
         """
         source = """\
         from automat import MethodicalMachine
@@ -329,7 +328,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
 
     def test_ignoresImportedClass(self):
         """
-        When given L{twisted.python.modules.PythonAttribute} that refers
+        When given a L{twisted.python.modules.PythonAttribute} that refers
         to a class imported from another module, any
         L{MethodicalMachine}s on that class are ignored.
 
@@ -396,7 +395,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
         """
         L{findMachinesViaWrapper} ignores infinite loops.
 
-        Note this test can't fail - it can only run forever...
+        Note this test can't fail - it can only run forever!
         """
         source = """
         class InfiniteLoop(object):
@@ -411,7 +410,7 @@ class FindMachinesViaWrapperTests(_WritesPythonModules):
 @skipIf(not isTwistedInstalled(), "Twisted is not installed.")
 class WrapFQPNTests(TestCase):
     """
-    Tests that ensure L{wrapFQPN} loads the correct
+    Tests that ensure L{wrapFQPN} loads the
     L{twisted.python.modules.PythonModule} or
     L{twisted.python.modules.PythonAttribute} for a given FQPN.
     """
@@ -429,9 +428,8 @@ class WrapFQPNTests(TestCase):
 
     def assertModuleWrapperRefersTo(self, moduleWrapper, module):
         """
-        Assert that a L{twisted.python.modules.PythonModule} refers to an
-        actual Python module.
-
+        Assert that a L{twisted.python.modules.PythonModule} refers to a
+        particular Python module.
         """
         self.assertIsInstance(moduleWrapper, self.PythonModule)
         self.assertEqual(moduleWrapper.name, module.__name__)
@@ -453,10 +451,10 @@ class WrapFQPNTests(TestCase):
         with self.assertRaises(self.InvalidFQPN):
             self.wrapFQPN('')
 
-    def test_failsWithIncorrectDotting(self):
+    def test_failsWithBadDotting(self):
         """"
-        L{wrapFQPN} raises L{InvalidFQPN} when given an
-        incorrectly-dotted FQPN
+        L{wrapFQPN} raises L{InvalidFQPN} when given a badly-dotted
+        FQPN.  (e.g., x..y).
         """
         for bad in ('.fails', 'fails.', 'this..fails'):
             with self.assertRaises(self.InvalidFQPN):
@@ -493,7 +491,7 @@ class WrapFQPNTests(TestCase):
     def test_multiplePackages(self):
         """
         L{wrapFQPN} returns a L{twisted.python.modules.PythonModule}
-        referring to the deepest module described by dotted FQPN.
+        referring to the deepest package described by dotted FQPN.
         """
         import xml.etree
         self.assertModuleWrapperRefersTo(self.wrapFQPN('xml.etree'), xml.etree)
@@ -510,7 +508,7 @@ class WrapFQPNTests(TestCase):
     def test_singleModuleObject(self):
         """
         L{wrapFQPN} returns a L{twisted.python.modules.PythonAttribute}
-        referring to the deepest object an FQPN with a depth of one module.
+        referring to the deepest object an FQPN names, traversing one module.
         """
         import os
         self.assertAttributeWrapperRefersTo(
@@ -519,8 +517,8 @@ class WrapFQPNTests(TestCase):
     def test_multiplePackagesObject(self):
         """
         L{wrapFQPN} returns a L{twisted.python.modules.PythonAttribute}
-        referring to the deepest object an FQPN that descends through
-        several packages.
+        referring to the deepest object described by an FQPN,
+        descending through several packages.
         """
         import xml.etree.ElementTree
         import automat
@@ -535,7 +533,7 @@ class WrapFQPNTests(TestCase):
     def test_failsWithMultiplePackagesMissingModuleOrPackage(self):
         """
         L{wrapFQPN} raises L{NoObject} when given an FQPN that contains a
-        missing attribute.
+        missing attribute, module, or package.
         """
         for bad in ('xml.etree.nope!',
                     'xml.etree.nope!.but.the.rest.is.believable'):

--- a/automat/_test/test_visualize.py
+++ b/automat/_test/test_visualize.py
@@ -7,10 +7,25 @@ from unittest import TestCase, skipIf
 
 from .._methodical import MethodicalMachine
 
+
+def isGraphvizModuleInstalled():
+    """
+    Is the graphviz Python module installed?
+    """
+    try:
+        import graphviz
+    except ImportError:
+        return False
+    else:
+        del graphviz
+        return True
+
+
 def isGraphvizInstalled():
     """
-    Is graphviz installed?
+    Are the graphviz tools installed?
     """
+
     r, w = os.pipe()
     os.close(w)
     try:
@@ -45,7 +60,8 @@ def sampleMachine():
 
 
 
-@skipIf(not isGraphvizInstalled(), "Graphviz is not installed.")
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
+@skipIf(not isGraphvizInstalled(), "Graphviz tools are not installed.")
 class IntegrationTests(TestCase):
     """
     Tests which make sure Graphviz can understand the output produced by
@@ -58,11 +74,12 @@ class IntegrationTests(TestCase):
         """
         p = subprocess.Popen("dot", stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE)
-        out, err = p.communicate("".join(sampleMachine().graphviz())
+        out, err = p.communicate("".join(sampleMachine().asDigraph())
                                  .encode("utf-8"))
         self.assertEqual(p.returncode, 0)
 
 
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
 class SpotChecks(TestCase):
     """
     Tests to make sure that the output contains salient features of the machine
@@ -74,7 +91,7 @@ class SpotChecks(TestCase):
         The output of L{graphviz} should contain the names of the states,
         inputs, outputs in the state machine.
         """
-        gvout = "".join(sampleMachine().graphviz())
+        gvout = "".join(sampleMachine().asDigraph())
         self.assertIn("begin", gvout)
         self.assertIn("end", gvout)
         self.assertIn("go", gvout)

--- a/automat/_test/test_visualize.py
+++ b/automat/_test/test_visualize.py
@@ -1,4 +1,6 @@
+from __future__ import print_function
 import functools
+import itertools
 
 import os
 import subprocess
@@ -8,7 +10,8 @@ from characteristic import attributes
 
 from .._methodical import MethodicalMachine
 
-from .._visualize import elementMaker, tableMaker
+from .._visualize import elementMaker, tableMaker, tool
+from .test_discover import isTwistedInstalled
 
 
 def isGraphvizModuleInstalled():
@@ -232,3 +235,182 @@ class SpotChecks(TestCase):
         self.assertIn("end", gvout)
         self.assertIn("go", gvout)
         self.assertIn("out", gvout)
+
+
+class RecordsDigraphActions(object):
+    """
+    Records calls made to L{FakeDigraph}.
+    """
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.renderCalls = []
+        self.saveCalls = []
+
+
+class FakeDigraph(object):
+    """
+    A fake L{graphviz.Digraph}.  Instantiate it with a
+    L{RecordsDigraphActions}.
+    """
+
+    def __init__(self, recorder):
+        self._recorder = recorder
+
+    def render(self, **kwargs):
+        self._recorder.renderCalls.append(kwargs)
+
+    def save(self, **kwargs):
+        self._recorder.saveCalls.append(kwargs)
+
+
+class FakeMethodicalMachine(object):
+    """
+    A fake L{MethodicalMachine}.  Instantiate it with a L{FakeDigraph}
+    """
+
+    def __init__(self, digraph):
+        self._digraph = digraph
+
+    def asDigraph(self):
+        return self._digraph
+
+
+@skipIf(not isGraphvizModuleInstalled(), "Graphviz module is not installed.")
+@skipIf(not isGraphvizInstalled(), "Graphviz tools are not installed.")
+@skipIf(not isTwistedInstalled(), "Twisted is not installed.")
+class VisualizeToolTests(TestCase):
+
+    def setUp(self):
+        self.digraphRecorder = RecordsDigraphActions()
+        self.fakeDigraph = FakeDigraph(self.digraphRecorder)
+
+        self.fakeProgname = 'tool-test'
+        self.fakeSysPath = ['ignored']
+        self.collectedOutput = []
+        self.fakeFQPN = 'fake.fqpn'
+
+    def collectPrints(self, *args):
+        self.collectedOutput.append(' '.join(args))
+
+    def fakeFindMachines(self, fqpn):
+        yield fqpn, FakeMethodicalMachine(self.fakeDigraph)
+
+    def tool(self,
+             progname=None,
+             argv=None,
+             syspath=None,
+             findMachines=None,
+             print=None):
+        return tool(
+            _progname=progname or self.fakeProgname,
+            _argv=argv or [self.fakeFQPN],
+            _syspath=syspath or self.fakeSysPath,
+            _findMachines=findMachines or self.fakeFindMachines,
+            _print=print or self.collectPrints)
+
+    def test_checksCurrentDirectory(self):
+        """
+        L{tool} adds '' to sys.path to ensure
+        L{automat._discover.findMachines} searches the current
+        directory.
+        """
+        self.tool(argv=[self.fakeFQPN])
+        self.assertEqual(self.fakeSysPath[0], '')
+
+    def test_quietHidesOutput(self):
+        """
+        Passing -q/--quiet hides all output.
+        """
+        self.tool(argv=[self.fakeFQPN, '--quiet'])
+        self.assertFalse(self.collectedOutput)
+        self.tool(argv=[self.fakeFQPN, '-q'])
+        self.assertFalse(self.collectedOutput)
+
+    def test_onlySaveDot(self):
+        """
+        Passing an empty string for --image-directory/-i disables
+        rendering images.
+        """
+        for arg in ('--image-directory', '-i'):
+            self.digraphRecorder.reset()
+            self.collectedOutput = []
+
+            self.tool(argv=[self.fakeFQPN, arg, ''])
+            self.assertFalse(any("image" in line
+                                 for line in self.collectedOutput))
+
+            self.assertEqual(len(self.digraphRecorder.saveCalls), 1)
+            (call,) = self.digraphRecorder.saveCalls
+            self.assertEqual("{}.dot".format(self.fakeFQPN),
+                             call['filename'])
+
+            self.assertFalse(self.digraphRecorder.renderCalls)
+
+    def test_saveOnlyImage(self):
+        """
+        Passing an empty string for --dot-directory/-d disables saving dot
+        files.
+        """
+        for arg in ('--dot-directory', '-d'):
+            self.digraphRecorder.reset()
+            self.collectedOutput = []
+            self.tool(argv=[self.fakeFQPN, arg, ''])
+
+            self.assertFalse(any("dot" in line
+                                 for line in self.collectedOutput))
+
+            self.assertEqual(len(self.digraphRecorder.renderCalls), 1)
+            (call,) = self.digraphRecorder.renderCalls
+            self.assertEqual("{}.dot".format(self.fakeFQPN),
+                             call['filename'])
+            self.assertTrue(call['cleanup'])
+
+            self.assertFalse(self.digraphRecorder.saveCalls)
+
+    def test_saveDotAndImagesInDifferentDirectories(self):
+        """
+        Passing different directories to --image-directory and --dot-directory
+        writes images and dot files to those directories.
+        """
+        imageDirectory = 'image'
+        dotDirectory = 'dot'
+        self.tool(argv=[self.fakeFQPN,
+                        '--image-directory', imageDirectory,
+                        '--dot-directory', dotDirectory])
+
+        self.assertTrue(any("image" in line
+                            for line in self.collectedOutput))
+        self.assertTrue(any("dot" in line
+                            for line in self.collectedOutput))
+
+        self.assertEqual(len(self.digraphRecorder.renderCalls), 1)
+        (renderCall,) = self.digraphRecorder.renderCalls
+        self.assertEqual(renderCall["directory"], imageDirectory)
+        self.assertTrue(renderCall['cleanup'])
+
+        self.assertEqual(len(self.digraphRecorder.saveCalls), 1)
+        (saveCall,) = self.digraphRecorder.saveCalls
+        self.assertEqual(saveCall["directory"], dotDirectory)
+
+    def test_saveDotAndImagesInSameDirectory(self):
+        """
+        Passing the same directory to --image-directory and --dot-directory
+        writes images and dot files to that one directory.
+        """
+        directory = 'imagesAndDot'
+        self.tool(argv=[self.fakeFQPN,
+                        '--image-directory', directory,
+                        '--dot-directory', directory])
+
+        self.assertTrue(any("image and dot" in line
+                            for line in self.collectedOutput))
+
+        self.assertEqual(len(self.digraphRecorder.renderCalls), 1)
+        (renderCall,) = self.digraphRecorder.renderCalls
+        self.assertEqual(renderCall["directory"], directory)
+        self.assertFalse(renderCall['cleanup'])
+
+        self.assertFalse(len(self.digraphRecorder.saveCalls))

--- a/automat/_visualize.py
+++ b/automat/_visualize.py
@@ -1,4 +1,11 @@
+from __future__ import print_function
+import argparse
+import sys
+
 import graphviz
+import graphviz.files
+
+from ._discover import findMachines
 
 
 def _gvquote(s):
@@ -98,3 +105,80 @@ def makeDigraph(automaton, inputAsString=repr,
                      stateAsString(outState))
 
     return digraph
+
+
+def tool(_progname=sys.argv[0],
+         _argv=sys.argv[1:],
+         _syspath=sys.path,
+         _findMachines=findMachines,
+         _print=print):
+    """
+    Entry point for command line utility.
+    """
+
+    DESCRIPTION = """
+    Visualize automat.MethodicalMachines as graphviz graphs.
+    """
+    EPILOG = """
+    You must have the graphviz tool suite installed.  Please visit
+    http://www.graphviz.org for more information.
+    """
+    if _syspath[0]:
+        _syspath.insert(0, '')
+    argumentParser = argparse.ArgumentParser(
+        prog=_progname,
+        description=DESCRIPTION,
+        epilog=EPILOG)
+    argumentParser.add_argument('fqpn',
+                                help="A Fully Qualified Path name"
+                                " representing where to find machines.")
+    argumentParser.add_argument('--quiet', '-q',
+                                help="suppress output",
+                                default=False,
+                                action="store_true")
+    argumentParser.add_argument('--dot-directory', '-d',
+                                help="Where to write out .dot files.",
+                                default=".automat_visualize")
+    argumentParser.add_argument('--image-directory', '-i',
+                                help="Where to write out image files.",
+                                default=".automat_visualize")
+    argumentParser.add_argument('--image-type', '-t',
+                                help="The image format.",
+                                choices=graphviz.files.FORMATS,
+                                default='png')
+    argumentParser.add_argument('--view', '-v',
+                                help="View rendered graphs with"
+                                " default image viewer",
+                                default=False,
+                                action="store_true")
+    args = argumentParser.parse_args(_argv)
+
+    explicitlySaveDot = (args.dot_directory
+                         and (not args.image_directory
+                              or args.image_directory != args.dot_directory))
+    if args.quiet:
+        def _print(*args):
+            pass
+
+    for fqpn, machine in _findMachines(args.fqpn):
+        _print(fqpn, '...discovered')
+
+        digraph = machine.asDigraph()
+
+        if explicitlySaveDot:
+            digraph.save(filename="{}.dot".format(fqpn),
+                         directory=args.dot_directory)
+            _print(fqpn, "...wrote dot into", args.dot_directory)
+
+        if args.image_directory:
+            deleteDot = not args.dot_directory or explicitlySaveDot
+            digraph.format = args.image_type
+            digraph.render(filename="{}.dot".format(fqpn),
+                           directory=args.image_directory,
+                           view=args.view,
+                           cleanup=deleteDot)
+            if deleteDot:
+                msg = "...wrote image into"
+            else:
+                msg = "...wrote image and dot into"
+            _print(fqpn, msg, args.image_directory)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ setup(
         "characteristic",
         "six",
     ],
+    extras_require={
+        'visualize': ['graphviz>=0.4.9']
+    },
     include_package_data=True,
     license="MIT",
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
         "six",
     ],
     extras_require={
-        'visualize': ['graphviz>=0.4.9']
+        'visualize': ['graphviz>=0.4.9',
+                      'Twisted>=16.1.1'],
     },
     include_package_data=True,
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,13 @@ setup(
         "six",
     ],
     extras_require={
-        'visualize': ['graphviz>=0.4.9',
-                      'Twisted>=16.1.1'],
+        "visualize": ["graphviz>=0.4.9",
+                      "Twisted>=16.1.1"],
+    },
+    entry_points={
+        "console_scripts": [
+            "automat-visualize = automat._visualize:tool"
+        ],
     },
     include_package_data=True,
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py27,pypy,py33,py34
 [testenv]
 deps =
     graphviz>=0.4.9
+    Twisted>=16.2.0
     coverage
     pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py27,pypy,py33,py34
 
 [testenv]
 deps =
+    graphviz>=0.4.9
     coverage
     pytest
 


### PR DESCRIPTION
Closes #5.

This PR builds on #20 so it appears slightly weightier than it is.  Make no mistake -- this is a very large PR, but I don't know if it could be made smaller.

There are again two commits:

1) Introduces the discovery logic used by the visualization tool.  This is largely cribbed from t.p.modules, and indeed the hardest part -- module exploration -- is handled by `PythonModule`.  Unfortunately there is no version of `namedAny` that returns `PythonModule` or `PythonAttributes` instead of actual objects.  This meant either using less of t.p.modules (which appears to be what `trial` does) or reimplementing `namedAny` in terms of t.p.modules objects.  I chose the latter.  An open question here: should `findMachinesViaWrapper` (and thus `findMachines`) accept an argument to ignore import-related errors?  This would allow for best-effort machine collection.

2) Introduces the command line tool itself.  This PR should probably also include proper documentation for publishing on readthedocs or the like, but given that I don't expect this to pass review, I'll hold off on that.

Most of the lines are in test files.  Some of that is related to awkwardness caused by unittest (such as no tmpdir affordance.)  If there's a portable way to tell unittest to skip a module and not a test, that could help cut down on the lines quite a bit; as it stands now, tests can't use py.test extensions or trial's `SynchronousTestCase`.