### PR TITLE
tox.ini now combines the coverage data from all test environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ script:
     - tox -e $TOX_ENV
 
 after_success:
+    - tox -e coverage-report
     - coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34
+envlist = coverage-clean,py27,pypy,py33,py34,coverage-report
 
 [testenv]
 deps =
@@ -7,5 +7,16 @@ deps =
     pytest
 
 commands =
-    coverage run --source automat -m py.test automat/_test
+    coverage run --parallel --source automat -m py.test automat/_test
+
+[testenv:coverage-clean]
+deps = coverage
+skip_install = true
+commands = coverage erase
+
+[testenv:coverage-report]
+deps = coverage
+skip_install = true
+commands =
+    coverage combine
     coverage report -m


### PR DESCRIPTION
Previously, each environment's coverage data overwrote any other's, so
that checking the coverage locally showed only the last run's results.

This approach was largely cribbed from
https://hynek.me/articles/testing-packaging/