### PR TITLE
Stop using graphviz's private FORMATS set.

### DIFF
--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -152,7 +152,7 @@ class MethodicalTests(TestCase):
             m = MethodicalMachine()
             @m.input()
             def input(self):
-                pass
+                "an input"
             @m.output()
             def outputA(self):
                 return "A"
@@ -161,7 +161,7 @@ class MethodicalTests(TestCase):
                 return "B"
             @m.state(initial=True)
             def state(self):
-                pass
+                "a state"
             state.upon(input, state, [outputA, outputB],
                        collector=lambda x: reduce(operator.add, x))
         m = Machine()
@@ -194,10 +194,10 @@ class MethodicalTests(TestCase):
             m = MethodicalMachine()
             @m.input()
             def input(self, x, y=1):
-                pass
+                "an input"
             @m.state(initial=True)
             def state(self):
-                pass
+                "a state"
             @m.output()
             def output(self, x, y=1):
                 self._x = x
@@ -218,16 +218,16 @@ class MethodicalTests(TestCase):
             m = MethodicalMachine()
             @m.input()
             def nameOfInput(self, a):
-                pass
+                "an input"
             @m.output()
             def outputThatMatches(self, a):
-                pass
+                "an output that matches"
             @m.output()
             def outputThatDoesntMatch(self, b):
-                pass
+                "an output that doesn't match"
             @m.state()
             def state(self):
-                pass
+                "a state"
             with self.assertRaises(TypeError) as cm:
                 state.upon(nameOfInput, state, [outputThatMatches,
                                                 outputThatDoesntMatch])
@@ -341,7 +341,7 @@ class MethodicalTests(TestCase):
                 "Second state."
             @m.input()
             def input(self):
-                pass
+                "an input"
             @m.output()
             def output(self):
                 self.value = 2

--- a/automat/_visualize.py
+++ b/automat/_visualize.py
@@ -8,6 +8,46 @@ import graphviz.files
 from ._discover import findMachines
 
 
+FORMATS = frozenset([  # http://www.graphviz.org/doc/info/output.html
+    'bmp',
+    'canon', 'dot', 'gv', 'xdot', 'xdot1.2', 'xdot1.4',
+    'cgimage',
+    'cmap',
+    'eps',
+    'exr',
+    'fig',
+    'gd', 'gd2',
+    'gif',
+    'gtk',
+    'ico',
+    'imap', 'cmapx',
+    'imap_np', 'cmapx_np',
+    'ismap',
+    'jp2',
+    'jpg', 'jpeg', 'jpe',
+    'pct', 'pict',
+    'pdf',
+    'pic',
+    'plain', 'plain-ext',
+    'png',
+    'pov',
+    'ps',
+    'ps2',
+    'psd',
+    'sgi',
+    'svg', 'svgz',
+    'tga',
+    'tif', 'tiff',
+    'tk',
+    'vml', 'vmlz',
+    'vrml',
+    'wbmp',
+    'webp',
+    'xlib',
+    'x11',
+])
+
+
 def _gvquote(s):
     return '"{}"'.format(s.replace('"', r'\"'))
 
@@ -143,7 +183,7 @@ def tool(_progname=sys.argv[0],
                                 default=".automat_visualize")
     argumentParser.add_argument('--image-type', '-t',
                                 help="The image format.",
-                                choices=graphviz.files.FORMATS,
+                                choices=FORMATS,
                                 default='png')
     argumentParser.add_argument('--view', '-v',
                                 help="View rendered graphs with"

--- a/automat/_visualize.py
+++ b/automat/_visualize.py
@@ -3,49 +3,8 @@ import argparse
 import sys
 
 import graphviz
-import graphviz.files
 
 from ._discover import findMachines
-
-
-FORMATS = frozenset([  # http://www.graphviz.org/doc/info/output.html
-    'bmp',
-    'canon', 'dot', 'gv', 'xdot', 'xdot1.2', 'xdot1.4',
-    'cgimage',
-    'cmap',
-    'eps',
-    'exr',
-    'fig',
-    'gd', 'gd2',
-    'gif',
-    'gtk',
-    'ico',
-    'imap', 'cmapx',
-    'imap_np', 'cmapx_np',
-    'ismap',
-    'jp2',
-    'jpg', 'jpeg', 'jpe',
-    'pct', 'pict',
-    'pdf',
-    'pic',
-    'plain', 'plain-ext',
-    'png',
-    'pov',
-    'ps',
-    'ps2',
-    'psd',
-    'sgi',
-    'svg', 'svgz',
-    'tga',
-    'tif', 'tiff',
-    'tk',
-    'vml', 'vmlz',
-    'vrml',
-    'wbmp',
-    'webp',
-    'xlib',
-    'x11',
-])
 
 
 def _gvquote(s):
@@ -183,7 +142,7 @@ def tool(_progname=sys.argv[0],
                                 default=".automat_visualize")
     argumentParser.add_argument('--image-type', '-t',
                                 help="The image format.",
-                                choices=FORMATS,
+                                choices=graphviz.FORMATS,
                                 default='png')
     argumentParser.add_argument('--view', '-v',
                                 help="View rendered graphs with"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "six",
     ],
     extras_require={
-        "visualize": ["graphviz>=0.4.9",
+        "visualize": ["graphviz>0.5.1",
                       "Twisted>=16.1.1"],
     },
     entry_points={


### PR DESCRIPTION
The argument parser uses it to fail early when given an unsupported
image format.  Since the graphviz library itself determines what image
formats it supports, the contents of the set isn't private, but its
location inside the graphviz Python package is.

This commit copies the set into _visualize to break the dependency on
this private API.