### PR TITLE
Remove automat.__main__.

### DIFF
--- a/automat/__main__.py
+++ b/automat/__main__.py
@@ -1,3 +1,0 @@
-from ._visualize import tool
-
-tool()


### PR DESCRIPTION
The automat-visualize console script is the only public API to the
visualizer for now.

(See https://github.com/glyph/automat/pull/32#issuecomment-266242546)