### PR TITLE
Conform author metadata to `distutils.core` API

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ setup(
             "automat-visualize = automat._visualize:tool"
         ],
     },
-    author_name='Glyph',
-    author_mail='glyph@twistedmatrix.com',
+    author='Glyph',
+    author_email='glyph@twistedmatrix.com',
     include_package_data=True,
     license="MIT",
     keywords='fsm finite state machine automata',


### PR DESCRIPTION
Update the `setup` keyword args for author contact to align with the
[`distutils.core` API](https://docs.python.org/3.6/distutils/apiref.html).