### PR TITLE
tox/travis: enable tests on py3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - TOX_ENV=py33-noextras
     - TOX_ENV=py34-extras
     - TOX_ENV=py34-noextras
+    - TOX_ENV=py35-extras
+    - TOX_ENV=py35-noextras
 
 install:
     - sudo apt-get install graphviz

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{py27,pypy,py33,py34}-{extras,noextras},coverage-report
+envlist = coverage-clean,{py27,pypy,py33,py34,py35}-{extras,noextras},coverage-report
 
 [testenv]
 deps =


### PR DESCRIPTION
just py3.5 this time

Travis doesn't include py3.6 on their default `language: python` image, so we'll need something extra to enable py3.6 support.