### PR TITLE
add tracing API, with docs

### DIFF
--- a/automat/_core.py
+++ b/automat/_core.py
@@ -154,16 +154,12 @@ class Transitioner(object):
         """
         Transition between states, returning any outputs.
         """
-        initialStateName = self._state._name()
-        inputName = inputSymbol._name()
         outState, outputSymbols = self._automaton.outputForInput(self._state,
                                                                  inputSymbol)
-        outputName = outState._name()
-        outTracer = lambda output: None
+        outTracer = None
         if self._tracer:
-            self._tracer(initialStateName, inputName, outputName, None)
-            def outTracer(output):
-                self._tracer(initialStateName, inputName, outputName, output)
-
+            outTracer = self._tracer(self._state._name(),
+                                     inputSymbol._name(),
+                                     outState._name())
         self._state = outState
         return (outputSymbols, outTracer)

--- a/automat/_core.py
+++ b/automat/_core.py
@@ -145,13 +145,25 @@ class Transitioner(object):
     def __init__(self, automaton, initialState):
         self._automaton = automaton
         self._state = initialState
+        self._tracer = None
 
+    def setTrace(self, tracer):
+        self._tracer = tracer
 
     def transition(self, inputSymbol):
         """
         Transition between states, returning any outputs.
         """
+        initialStateName = self._state._name()
+        inputName = inputSymbol._name()
         outState, outputSymbols = self._automaton.outputForInput(self._state,
                                                                  inputSymbol)
+        outputName = outState._name()
+        outTracer = lambda output: None
+        if self._tracer:
+            self._tracer(initialStateName, inputName, outputName, None)
+            def outTracer(output):
+                self._tracer(initialStateName, inputName, outputName, output)
+
         self._state = outState
-        return outputSymbols
+        return (outputSymbols, outTracer)

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -61,6 +61,9 @@ class MethodicalState(object):
                 ))
         self.machine._oneTransition(self, input, enter, outputs, collector)
 
+    def _name(self):
+        return self.method.__name__
+
 
 def _transitionerFromInstance(oself, symbol, automaton):
     """
@@ -123,11 +126,18 @@ class MethodicalInput(object):
         def doInput(*args, **kwargs):
             self.method(oself, *args, **kwargs)
             previousState = transitioner._state
-            outputs = transitioner.transition(self)
+            (outputs, outTracer) = transitioner.transition(self)
             collector = self.collectors[previousState]
-            return collector(output(oself, *args, **kwargs)
-                             for output in outputs)
+            values = []
+            for output in outputs:
+                outTracer(output._name())
+                value = output(oself, *args, **kwargs)
+                values.append(value)
+            return collector(values)
         return doInput
+
+    def _name(self):
+        return self.method.__name__
 
 
 @attr.s
@@ -156,6 +166,22 @@ class MethodicalOutput(object):
         Call the underlying method.
         """
         return self.method(oself, *args, **kwargs)
+
+    def _name(self):
+        return self.method.__name__
+
+@attr.s(cmp=False, hash=False)
+class MethodicalTracer(object):
+    automaton = attr.ib(repr=False)
+    symbol = attr.ib(repr=False)
+
+
+    def __get__(self, oself, type=None):
+        transitioner = _transitionerFromInstance(oself, self.symbol,
+                                                 self.automaton)
+        def setTrace(tracer):
+            transitioner.setTrace(tracer)
+        return setTrace
 
 
 
@@ -312,6 +338,9 @@ class MethodicalMachine(object):
             return unserialize
         return decorator
 
+    @property
+    def setTrace(self):
+        return MethodicalTracer(self._automaton, self._symbol)
 
     def asDigraph(self):
         """

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -130,7 +130,8 @@ class MethodicalInput(object):
             collector = self.collectors[previousState]
             values = []
             for output in outputs:
-                outTracer(output._name())
+                if outTracer:
+                    outTracer(output._name())
                 value = output(oself, *args, **kwargs)
                 values.append(value)
             return collector(values)

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -340,7 +340,7 @@ class MethodicalMachine(object):
         return decorator
 
     @property
-    def setTrace(self):
+    def _setTrace(self):
         return MethodicalTracer(self._automaton, self._symbol)
 
     def asDigraph(self):

--- a/automat/_test/test_trace.py
+++ b/automat/_test/test_trace.py
@@ -36,10 +36,39 @@ class SampleObject(object):
     middle.upon(back, begin, [])
 
 class TraceTests(TestCase):
-    def test_trace(self):
+    def test_only_inputs(self):
         traces = []
-        def tracer(old_state, input, new_state, output):
-            traces.append((old_state, input, new_state, output))
+        def tracer(old_state, input, new_state):
+            traces.append((old_state, input, new_state))
+            return None # "I only care about inputs, not outputs"
+        s = SampleObject()
+        s.setTrace(tracer)
+
+        s.go1()
+        self.assertEqual(traces, [("begin", "go1", "middle"),
+                                  ])
+
+        s.go2()
+        self.assertEqual(traces, [("begin", "go1", "middle"),
+                                  ("middle", "go2", "end"),
+                                  ])
+        s.setTrace(None)
+        s.back()
+        self.assertEqual(traces, [("begin", "go1", "middle"),
+                                  ("middle", "go2", "end"),
+                                  ])
+        s.go2()
+        self.assertEqual(traces, [("begin", "go1", "middle"),
+                                  ("middle", "go2", "end"),
+                                  ])
+
+    def test_inputs_and_outputs(self):
+        traces = []
+        def tracer(old_state, input, new_state):
+            traces.append((old_state, input, new_state, None))
+            def trace_outputs(output):
+                traces.append((old_state, input, new_state, output))
+            return trace_outputs # "I care about outputs too"
         s = SampleObject()
         s.setTrace(tracer)
 

--- a/automat/_test/test_trace.py
+++ b/automat/_test/test_trace.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+from .._methodical import MethodicalMachine
+
+class SampleObject(object):
+    mm = MethodicalMachine()
+
+    @mm.state(initial=True)
+    def begin(self):
+        "initial state"
+    @mm.state()
+    def middle(self):
+        "middle state"
+    @mm.state()
+    def end(self):
+        "end state"
+
+    @mm.input()
+    def go1(self):
+        "sample input"
+    @mm.input()
+    def go2(self):
+        "sample input"
+    @mm.input()
+    def back(self):
+        "sample input"
+
+    @mm.output()
+    def out(self):
+        "sample output"
+
+    setTrace = mm.setTrace
+
+    begin.upon(go1, middle, [out])
+    middle.upon(go2, end, [out])
+    end.upon(back, middle, [])
+    middle.upon(back, begin, [])
+
+class TraceTests(TestCase):
+    def test_trace(self):
+        traces = []
+        def tracer(old_state, input, new_state, output):
+            traces.append((old_state, input, new_state, output))
+        s = SampleObject()
+        s.setTrace(tracer)
+
+        s.go1()
+        self.assertEqual(traces, [("begin", "go1", "middle", None),
+                                  ("begin", "go1", "middle", "out"),
+                                  ])
+
+        s.go2()
+        self.assertEqual(traces, [("begin", "go1", "middle", None),
+                                  ("begin", "go1", "middle", "out"),
+                                  ("middle", "go2", "end", None),
+                                  ("middle", "go2", "end", "out"),
+                                  ])
+        s.setTrace(None)
+        s.back()
+        self.assertEqual(traces, [("begin", "go1", "middle", None),
+                                  ("begin", "go1", "middle", "out"),
+                                  ("middle", "go2", "end", None),
+                                  ("middle", "go2", "end", "out"),
+                                  ])
+        s.go2()
+        self.assertEqual(traces, [("begin", "go1", "middle", None),
+                                  ("begin", "go1", "middle", "out"),
+                                  ("middle", "go2", "end", None),
+                                  ("middle", "go2", "end", "out"),
+                                  ])

--- a/automat/_test/test_trace.py
+++ b/automat/_test/test_trace.py
@@ -28,7 +28,7 @@ class SampleObject(object):
     def out(self):
         "sample output"
 
-    setTrace = mm.setTrace
+    setTrace = mm._setTrace
 
     begin.upon(go1, middle, [out])
     middle.upon(go2, end, [out])

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,133 @@
+# Tracing API
+
+The tracing API lets you assign a callback function that will be invoked each
+time an input event causes the state machine to move from one state to
+another. This can help you figure out problems caused by events occurring in
+the wrong order, or not happening at all. Your callback function can print a
+message to stdout, write something to a logfile, or deliver the information
+in any application-specific way you like.
+
+To prepare the state machine for tracing, you must assign a name to the
+"setTrace" method in your class. In this example, we use
+`setTheTracingFunction`, but the name can be anything you like:
+
+```python
+class Sample(object):
+    mm = MethodicalMachine()
+    
+    @mm.state(initial=True)
+    def begin(self):
+        "initial state"
+    @mm.state()
+    def end(self):
+        "end state"
+    @mm.input()
+    def go(self):
+        "event that moves us from begin to end"
+    @mm.output()
+    def doThing1(self):
+        "first thing to do"
+    @mm.output()
+    def doThing2(self):
+        "second thing to do"
+    
+    setTheTracingFunction = mm.setTrace
+    
+    begin.upon(go, enter=end, outputs=[doThing1, doThing2])
+```
+
+Later, after you instantiate the `Sample` object, you can set the tracing
+callback for that particular instance by calling the
+`setTheTracingFunction()` method on it:
+
+```python
+s = Sample()
+def tracer(oldState, input, newState, output):
+    pass
+s.setTheTracingFunction(tracer)
+```
+
+Note that you cannot shortcut the name-assignment step:
+`s.mm.setTrace(tracer)` will not work, because Automat goes to great lengths
+to hide that `mm` object from external access. And you cannot set the tracing
+function at class-definition time (e.g. a class-level `mm.setTrace(tracer)`)
+because the state machine has merely been *defined* at that point, not
+instantiated (you might eventually have multiple instances of the Sample
+class, each with their own independent state machine).
+
+## The Tracer Callback Function
+
+When the input event is received, before any transitions are made, the tracer
+function is called with four positional arguments:
+
+* `oldState`: a string with the name of the current state
+* `input`: a string with the name of the input event
+* `newState`: a string with the name of the new state
+* `output`: None
+
+In addition, just before each output function is executed (if any), the
+tracer function will be called again, with the same
+`oldState`/`input`/`newState` arguments, plus an additional `output` string
+(with the name of the output function being invoked).
+
+If you only care about the transitions, your tracing function can just do
+nothing unless `output is None`:
+
+```python
+ s = Sample()
+ def tracer(oldState, input, newState, output):
+     if output is None:
+         print("%s.%s -> %s" % (oldState, input, newState))
+ s.setTheTracingFunction(tracer)
+ s.go()
+ # prints:
+ # begin.go -> end
+```
+
+But if you want to know when each output is invoked (perhaps to compare
+against other log messages emitted from inside those output functions), you
+should look at `output` too:
+
+```python
+ s = Sample()
+ def tracer(oldState, input, newState, output):
+     if output is None:
+         print("%s.%s -> %s" % (oldState, input, newState))
+     else:
+         print("%s.%s -> %s: %s()" % (oldState, input, newState, output))
+ s.setTheTracingFunction(tracer)
+ s.go()
+ # prints:
+ # begin.go -> end
+ # begin.go -> end: doThing1()
+ # begin.go -> end: doThing2()
+```
+
+
+## Tracing Multiple State Machines
+
+If you have multiple state machines in your application, you will probably
+want to pass a different tracing function to each, so your logs can
+distinguish between the transitions of MachineFoo vs those of MachineBar.
+This is particularly important if your application involves network
+communication, where an instance of MachineFoo (e.g. in a client) is
+communication with a sibling instance of MachineFoo (in a server). When
+exercising both sides of this connection in a single process, perhaps in an
+automated test, you will need to clearly mark the first as "foo1" and the
+second as "foo2" to avoid confusion.
+
+```python
+ s1 = Sample()
+ s2 = Sample()
+ def tracer1(oldState, input, newState, output):
+     if output is None:
+         print("S1: %s.%s -> %s" % (oldState, input, newState))
+ s1.setTheTracingFunction(tracer1)
+ def tracer2(oldState, input, newState, output):
+     if output is None:
+         print("S2: %s.%s -> %s" % (oldState, input, newState))
+ s2.setTheTracingFunction(tracer2)
+ ```
+
+Of course you can reduce the boilerplate required by (careful) use of
+closures, lambdas, and default arguments.


### PR DESCRIPTION
refs #36 

This seems useful for my own debugging purposes, where the logging function is just `print()`.

Some questions still in my mind:

* Is the tracing function sufficient to collect transition-coverage information, for #37/#38?
* This replaces the generator of outputs with a list, which probably inadvertently fixes #30
* The use of output=None vs output=(string) doesn't really capture the causality of transitions and their output functions being invoked. A properly structured logging framework (like Eliot or Foolscap) would be unsatisfied. Some other approaches would be:
  * register two separate logging functions (one for transitions, another for outputs), and have the return value from the first get passed as an extra argument into the second
  * pass an additional argument with some sort of (hashable) opaque token, that we promise will be identical for all calls involving the same transition
* should we make the `__str__` of States/Inputs/Outputs be just the name of the method, and then have the tracer use `str(oldState)` instead of `oldState._name()`? I have a patch to improve the `__str__` elsewhere, but I had been planning to make it be e.g. `"State($name)"` rather than just `"$name"`.
* are y'all comfortable with changing the return value of `transition()` to be a tuple like that? And with defining the `outTracer` closure inside `transition()`? It seemed like the easiest way to get a linked tracing function into `doInput()` where the outputs actually get run. If we change the way that outputs get logged, maybe we could avoid doing that, somehow.

