### PR TITLE
tox/travis: enable tests on py3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,35 @@
 language: python
-python: 2.7
-env:
-    - TOX_ENV=py27-extras
-    - TOX_ENV=py27-noextras
-    - TOX_ENV=pypy-extras
-    - TOX_ENV=pypy-noextras
-    - TOX_ENV=py33-extras
-    - TOX_ENV=py33-noextras
-    - TOX_ENV=py34-extras
-    - TOX_ENV=py34-noextras
-    - TOX_ENV=py35-extras
-    - TOX_ENV=py35-noextras
-    - TOX_ENV=py36-extras
-    - TOX_ENV=py36-noextras
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=py27-extras
+    - python: 2.7
+      env: TOX_ENV=py27-noextras
+
+    - python: pypy
+      env: TOX_ENV=pypy-extras
+    - python: pypy
+      env: TOX_ENV=pypy-noextras
+
+    - python: 3.3
+      env: TOX_ENV=py33-extras
+    - python: 3.3
+      env: TOX_ENV=py33-noextras
+
+    - python: 3.4
+      env: TOX_ENV=py34-extras
+    - python: 3.4
+      env: TOX_ENV=py34-noextras
+
+    - python: 3.5
+      env: TOX_ENV=py35-extras
+    - python: 3.5
+      env: TOX_ENV=py35-noextras
+
+    - python: 3.6
+      env: TOX_ENV=py36-extras
+    - python: 3.6
+      env: TOX_ENV=py36-noextras
 
 install:
     - sudo apt-get install graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - TOX_ENV=py34-noextras
     - TOX_ENV=py35-extras
     - TOX_ENV=py35-noextras
+    - TOX_ENV=py36-extras
+    - TOX_ENV=py36-noextras
 
 install:
     - sudo apt-get install graphviz

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{py27,pypy,py33,py34,py35}-{extras,noextras},coverage-report
+envlist = coverage-clean,{py27,pypy,py33,py34,py35,py36}-{extras,noextras},coverage-report
 
 [testenv]
 deps =


### PR DESCRIPTION
~Now that travis supports py3.6 directly, this is a lot easier.~

Edit: travis hasn't changed. I had to rewrite the .travis.yml to create separate environments for each target version.