### PR TITLE
improve function-is-empty test to work on py3.6 too

### DIFF
--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -83,10 +83,16 @@ def _docstring():
 _docstring()
 
 def assertNoCode(inst, attribute, f):
-    # the function body must be empty, i.e. "pass" or "return None", which
+    # The function body must be empty, i.e. "pass" or "return None", which
     # both yield the same bytecode: LOAD_CONST (None), RETURN_VALUE. We also
     # accept functions with only a docstring, which yields slightly different
     # bytecode, because the "None" is put in a different constant slot.
+
+    # Unfortunately, this does not catch function bodies that return a
+    # constant value, e.g. "return 1", because their code is identical to a
+    # "return None". They differ in the contents of their constant table, but
+    # checking that would require us to parse the bytecode, find the index
+    # being returned, then making sure the table has a None at that index.
     def ordify(bytecode):
         return [ord(bytecode[i:i+1]) for i in range(len(bytecode))]
     expected_empty = ordify(_empty.__code__.co_code)

--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -75,12 +75,12 @@ def _transitionerFromInstance(oself, symbol, automaton):
         setattr(oself, symbol, transitioner)
     return transitioner
 
+
 def _empty():
     pass
-_empty() # chase coverage
+
 def _docstring():
     """docstring"""
-_docstring()
 
 def assertNoCode(inst, attribute, f):
     # The function body must be empty, i.e. "pass" or "return None", which
@@ -93,13 +93,11 @@ def assertNoCode(inst, attribute, f):
     # "return None". They differ in the contents of their constant table, but
     # checking that would require us to parse the bytecode, find the index
     # being returned, then making sure the table has a None at that index.
-    def ordify(bytecode):
-        return [ord(bytecode[i:i+1]) for i in range(len(bytecode))]
-    expected_empty = ordify(_empty.__code__.co_code)
-    expected_docstring = ordify(_docstring.__code__.co_code)
-    bytecode = ordify(f.__code__.co_code)
-    if bytecode not in (expected_empty, expected_docstring):
+
+    if f.__code__.co_code not in (_empty.__code__.co_code,
+                                  _docstring.__code__.co_code):
         raise ValueError("function body must be empty")
+
 
 @attr.s(cmp=False, hash=False)
 class MethodicalInput(object):

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -222,7 +222,7 @@ class MethodicalTests(TestCase):
                 @m.input()
                 def input(self):
                     "an input"
-                    x = 1 # pragma: no cover
+                    list() # pragma: no cover
             self.assertEqual(str(cm.exception), "function body must be empty")
 
         # all three of these cases should be valid. Functions/methods with
@@ -239,7 +239,7 @@ class MethodicalTests(TestCase):
             start.upon(input, enter=start, outputs=[])
         MechanismWithDocstring().input()
 
-        class MechanismWithoutDocstring(object):
+        class MechanismWithPass(object):
             m = MethodicalMachine()
             @m.input()
             def input(self):
@@ -248,7 +248,19 @@ class MethodicalTests(TestCase):
             def start(self):
                 "starting state"
             start.upon(input, enter=start, outputs=[])
-        MechanismWithoutDocstring().input()
+        MechanismWithPass().input()
+
+        class MechanismWithDocstringAndPass(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                "an input"
+                pass
+            @m.state(initial=True)
+            def start(self):
+                "starting state"
+            start.upon(input, enter=start, outputs=[])
+        MechanismWithDocstringAndPass().input()
 
         class MechanismReturnsNone(object):
             m = MethodicalMachine()
@@ -260,6 +272,18 @@ class MethodicalTests(TestCase):
                 "starting state"
             start.upon(input, enter=start, outputs=[])
         MechanismReturnsNone().input()
+
+        class MechanismWithDocstringAndReturnsNone(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                "an input"
+                return None
+            @m.state(initial=True)
+            def start(self):
+                "starting state"
+            start.upon(input, enter=start, outputs=[])
+        MechanismWithDocstringAndReturnsNone().input()
 
 
 

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -7,6 +7,7 @@ from functools import reduce
 from unittest import TestCase
 
 from .. import MethodicalMachine, NoTransition
+from .. import _methodical
 
 class MethodicalTests(TestCase):
     """
@@ -215,6 +216,9 @@ class MethodicalTests(TestCase):
         """
         # input functions are executed to assert that the signature matches,
         # but their body must be empty
+
+        _methodical._empty() # chase coverage
+        _methodical._docstring()
 
         class Mechanism(object):
             m = MethodicalMachine()

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -225,6 +225,28 @@ class MethodicalTests(TestCase):
                     x = 1 # pragma: no cover
             self.assertEqual(str(cm.exception), "function body must be empty")
 
+        # all three of these cases should be valid. Functions/methods with
+        # docstrings produce slightly different bytecode than ones without.
+
+        class MechanismWithDocstring(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                "an input"
+
+        class MechanismWithoutDocstring(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                pass
+
+        class MechanismReturnsNone(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                return None
+
+
 
     def test_inputOutputMismatch(self):
         """

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -233,18 +233,33 @@ class MethodicalTests(TestCase):
             @m.input()
             def input(self):
                 "an input"
+            @m.state(initial=True)
+            def start(self):
+                "starting state"
+            start.upon(input, enter=start, outputs=[])
+        MechanismWithDocstring().input()
 
         class MechanismWithoutDocstring(object):
             m = MethodicalMachine()
             @m.input()
             def input(self):
                 pass
+            @m.state(initial=True)
+            def start(self):
+                "starting state"
+            start.upon(input, enter=start, outputs=[])
+        MechanismWithoutDocstring().input()
 
         class MechanismReturnsNone(object):
             m = MethodicalMachine()
             @m.input()
             def input(self):
                 return None
+            @m.state(initial=True)
+            def start(self):
+                "starting state"
+            start.upon(input, enter=start, outputs=[])
+        MechanismReturnsNone().input()
 
 
 


### PR DESCRIPTION
This should be more future-proof, as it compares the target Input's bytecode
against one of two samples (which will be compiled by the same interpreter as
the target), rather than comparing it against magic integers.

This passes manual local tests (with a modified tox.ini that adds a py3.6 target).
