### PR TITLE
Make hashable classes frozen for attrs 17.1.0 (fixes #62).

### DIFF
--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -31,7 +31,7 @@ def _keywords_only(f):
     return g
 
 
-@attr.s
+@attr.s(frozen=True)
 class MethodicalState(object):
     """
     A state for a L{MethodicalMachine}.
@@ -141,7 +141,7 @@ class MethodicalInput(object):
         return self.method.__name__
 
 
-@attr.s
+@attr.s(frozen=True)
 class MethodicalOutput(object):
     """
     An output for a L{MethodicalMachine}.


### PR DESCRIPTION
This version of attrs no longer makes classes hashable by default.
Instead, hashability must be explicitly requested or the class must be
made frozen.

MethodicalInput and MethodicalOutput are both added to a set inside
_core.Automaton, so they both have to be hashable.  Neither are ever
modified, however, so they can be made frozen and thus hashable.