### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,17 @@ setup(
     include_package_data=True,
     license="MIT",
     keywords='fsm finite state machine automata',
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
Without language classifiers in `setup.py` this project gets marked as not supporting Python 3 when using a tool like [caniusepython3.com](https://caniusepython3.com) to check Python 3 compatibility. I've added the basic classifiers, the most important ones being the language ones.