### PR TITLE
Update automat_example.py

### DIFF
--- a/docs/examples/automat_example.py
+++ b/docs/examples/automat_example.py
@@ -101,7 +101,7 @@ class FoodSlot(object):
     @machine.output()
     def unlockDoor(self):
         """
-        Lock the door, we don't need food.
+        Unock the door, it's chow time!.
         """
         self._door.unlock()
 


### PR DESCRIPTION
`unlockDoor` needs it's own docstring.  (was duplicate of `lockDoor`'s docstring)