### PR TITLE
remove python 3.3 from test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
     - python: pypy
       env: TOX_ENV=pypy-noextras
 
-    - python: 3.3
-      env: TOX_ENV=py33-extras
-    - python: 3.3
-      env: TOX_ENV=py33-noextras
+#    - python: 3.3
+#      env: TOX_ENV=py33-extras
+#    - python: 3.3
+#      env: TOX_ENV=py33-noextras
 
     - python: 3.4
       env: TOX_ENV=py34-extras


### PR DESCRIPTION
twisted requires python 3.4+
In relation to PR #95 TravisCI error