### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,6 @@ matrix:
     - python: pypy
       env: TOX_ENV=pypy-noextras
 
-#    - python: 3.3
-#      env: TOX_ENV=py33-extras
-#    - python: 3.3
-#      env: TOX_ENV=py33-noextras
-
     - python: 3.4
       env: TOX_ENV=py34-extras
     - python: 3.4

--- a/automat/_core.py
+++ b/automat/_core.py
@@ -94,8 +94,8 @@ class Automaton(object):
         """
         The full set of symbols acceptable to this automaton.
         """
-        return set(inputSymbol for (inState, inputSymbol, outState,
-                                    outputSymbol) in self._transitions)
+        return {inputSymbol for (inState, inputSymbol, outState,
+                                 outputSymbol) in self._transitions}
 
 
     def outputAlphabet(self):

--- a/automat/_test/test_core.py
+++ b/automat/_test/test_core.py
@@ -46,11 +46,11 @@ class CoreTests(TestCase):
         """
         a = Automaton()
         a.addTransition("beginning", "begin", "ending", ["end"])
-        self.assertEqual(a.inputAlphabet(), set(["begin"]))
-        self.assertEqual(a.outputAlphabet(), set(["end"]))
+        self.assertEqual(a.inputAlphabet(), {"begin"})
+        self.assertEqual(a.outputAlphabet(), {"end"})
         self.assertEqual(a.outputForInput("beginning", "begin"),
                          ("ending", ["end"]))
-        self.assertEqual(a.states(), set(["beginning", "ending"]))
+        self.assertEqual(a.states(), {"beginning", "ending"})
 
 
     def test_oneTransition_nonIterableOutputs(self):

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = coverage-clean,{py27,pypy,py33,py34,py35,py36}-{extras,noextras},coverage-report
+envlist = coverage-clean,{py27,pypy,py34,py35,py36}-{extras,noextras},coverage-report
 
 [testenv]
 deps =
@@ -28,10 +28,6 @@ deps = pytest-benchmark
 commands = pytest --benchmark-only benchmark/
 
 [testenv:py27-benchmark]
-deps = {[testenv:benchmark]deps}
-commands = {[testenv:benchmark]commands}
-
-[testenv:py33-benchmark]
 deps = {[testenv:benchmark]deps}
 commands = {[testenv:benchmark]commands}
 


### PR DESCRIPTION
Python 3.3 was commented out from the CI in #98.

As Python 3.3 is EOL and no longer receiving security updates (or any updates) from the core Python team, let's remove it instead of commenting out.

Also remove 3.3 from:
* https://github.com/glyph/automat/blob/master/setup.py#L55
* https://github.com/glyph/automat/blob/master/tox.ini#L2

This also upgrades Python syntax with https://github.com/asottile/pyupgrade.

---

Pip installs for automat from PyPI for May 2018:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |  57.26% |        100,491 |
| 3.6            |  24.31% |         42,663 |
| 3.5            |  16.10% |         28,255 |
| 3.4            |   1.93% |          3,385 |
| 3.7            |   0.40% |            697 |
| 2.6            |   0.01% |             12 |
| 3.3            |   0.00% |              8 |
| 3.2            |   0.00% |              2 |
| Total          |         |        175,513 |

Source: `pypinfo --start-date 2018-05-01 --end-date 2018-05-31 --percent --markdown automat pyversion`