### PR TITLE
Add support for positional only arguments

### DIFF
--- a/automat/_introspection.py
+++ b/automat/_introspection.py
@@ -13,6 +13,9 @@ def copycode(template, changes):
     ]
     if hasattr(code, "co_kwonlyargcount"):
         names.insert(1, "kwonlyargcount")
+    if hasattr(code, "co_posonlyargcount"):
+        # PEP 570 added "positional only arguments"
+        names.insert(1, "posonlyargcount")
     values = [
         changes.get(name, getattr(template, "co_" + name))
         for name in names


### PR DESCRIPTION
PEP 570 adds "positional only" arguments to Python, which changes the
code object constructor. This adds support for Python 3.8.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>


Tested in Fedora Rawhide with Python 3.8a4.