### PR TITLE
constrain twisted dep for python 3.4

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,13 @@ commands = {[testenv:benchmark]commands}
 deps = {[testenv:benchmark]deps}
 commands = {[testenv:benchmark]commands}
 
+[testenv:py34-extras]
+deps =
+    coverage
+    pytest
+    graphviz>=0.4.9
+    Twisted>=16.2.0,<19.7.0
+
 [testenv:py35-benchmark]
 deps = {[testenv:benchmark]deps}
 commands = {[testenv:benchmark]commands}


### PR DESCRIPTION
This fixes the failing build on master.