### PR TITLE
Add support for positional only arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,6 @@ matrix:
     - python: 3.8
       env: TOX_ENV=py38-noextras
 
-jobs:
-  allow_failures:
-    - python: 3.8
-
 install:
     - sudo apt-get install graphviz
     - pip install tox coveralls

--- a/automat/_introspection.py
+++ b/automat/_introspection.py
@@ -13,6 +13,9 @@ def copycode(template, changes):
     ]
     if hasattr(code, "co_kwonlyargcount"):
         names.insert(1, "kwonlyargcount")
+    if hasattr(code, "co_posonlyargcount"):
+        # PEP 570 added "positional only arguments"
+        names.insert(1, "posonlyargcount")
     values = [
         changes.get(name, getattr(template, "co_" + name))
         for name in names

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
PEP 570 adds "positional only" arguments to Python, which changes the
code object constructor. This adds support for Python 3.8.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

(update of #111)