### PR TITLE
Use setuptools-scm that is compat with Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=[]),
     package_dir={'automat': 'automat'},
     setup_requires=[
-        'setuptools-scm',
+        'setuptools-scm<6.0.0',
         'm2r',
     ],
     install_requires=[


### PR DESCRIPTION

The setuptools-scm >= 6.0.0 is now Python 3 only. https://pypi.org/project/setuptools-scm/6.0.0/. It was released on March 17, 2021. 

The last version that is also compat with is https://pypi.org/project/setuptools-scm/5.0.2/