### PR TITLE
Fix #17: Allow enter to have a default

### DIFF
--- a/automat/_methodical.py
+++ b/automat/_methodical.py
@@ -91,7 +91,7 @@ class MethodicalState(object):
     method = attr.ib()
     serialized = attr.ib(repr=False)
 
-    def upon(self, input, enter, outputs, collector=list):
+    def upon(self, input, enter=None, outputs=None, collector=list):
         """
         Declare a state transition within the :class:`automat.MethodicalMachine`
         associated with this :class:`automat.MethodicalState`:
@@ -110,6 +110,10 @@ class MethodicalState(object):
         :raises ValueError: if the state transition from `self` via `input`
             has already been defined.
         """
+        if enter is None:
+            enter = self
+        if outputs is None:
+            outputs = []
         inputArgs = _getArgNames(input.argSpec)
         for output in outputs:
             outputArgs = _getArgNames(output.argSpec)

--- a/automat/_test/test_methodical.py
+++ b/automat/_test/test_methodical.py
@@ -365,6 +365,50 @@ class MethodicalTests(TestCase):
             self.assertIn("nameOfInput", str(cm.exception))
             self.assertIn("outputThatDoesntMatch", str(cm.exception))
 
+    def test_stateLoop(self):
+        """
+        It is possible to write a self-loop by omitting "enter"
+        """
+        class Mechanism(object):
+            m = MethodicalMachine()
+            @m.input()
+            def input(self):
+                "an input"
+            @m.input()
+            def say_hi(self):
+                "an input"
+            @m.output()
+            def _start_say_hi(self):
+                return "hi"
+            @m.state(initial=True)
+            def start(self):
+                "a state"
+            def said_hi(self):
+                "a state with no inputs"
+            start.upon(input, outputs=[])
+            start.upon(say_hi, outputs=[_start_say_hi])
+        a_mechanism = Mechanism()
+        [a_greeting] = a_mechanism.say_hi()
+        self.assertEqual(a_greeting, "hi")
+
+
+    def test_defaultOutputs(self):
+        """
+        It is possible to write a transition with no outputs
+        """
+        class Mechanism(object):
+            m = MethodicalMachine()
+            @m.input()
+            def finish(self):
+                "final transition"
+            @m.state(initial=True)
+            def start(self):
+                "a start state"
+            @m.state()
+            def finished(self):
+                "a final state"
+            start.upon(finish, enter=finished)
+        Mechanism().finish()
 
     def test_getArgNames(self):
         """


### PR DESCRIPTION
Since enter follows outputs, and there are some use cases
(including in the tests) which use the argument order,
this also allows outputs to have a default. This has been
discussed before (in the same ticket) as desirable.