### PR TITLE
Use CodeType.replace() in copycode for Python > 3.8

### DIFF
--- a/automat/_introspection.py
+++ b/automat/_introspection.py
@@ -6,22 +6,24 @@ from types import CodeType as code, FunctionType as function
 
 
 def copycode(template, changes):
-    names = [
-        "argcount", "nlocals", "stacksize", "flags", "code", "consts",
-        "names", "varnames", "filename", "name", "firstlineno", "lnotab",
-        "freevars", "cellvars"
-    ]
-    if hasattr(code, "co_kwonlyargcount"):
-        names.insert(1, "kwonlyargcount")
-    if hasattr(code, "co_posonlyargcount"):
-        # PEP 570 added "positional only arguments"
-        names.insert(1, "posonlyargcount")
-    values = [
-        changes.get(name, getattr(template, "co_" + name))
-        for name in names
-    ]
-    return code(*values)
-
+    if hasattr(code, "replace"):
+        return template.replace(**{"co_" + k : v for k, v in changes.items()})
+    else:
+        names = [
+            "argcount", "nlocals", "stacksize", "flags", "code", "consts",
+            "names", "varnames", "filename", "name", "firstlineno", "lnotab",
+            "freevars", "cellvars"
+        ]
+        if hasattr(code, "co_kwonlyargcount"):
+            names.insert(1, "kwonlyargcount")
+        if hasattr(code, "co_posonlyargcount"):
+            # PEP 570 added "positional only arguments"
+            names.insert(1, "posonlyargcount")
+        values = [
+            changes.get(name, getattr(template, "co_" + name))
+            for name in names
+        ]
+        return code(*values)
 
 
 def copyfunction(template, funcchanges, codechanges):


### PR DESCRIPTION
Fix #135