### PR TITLE
Fix metadata after remove Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
After this commit - https://github.com/glyph/automat/commit/c8e76be612eb7e0b4caed121bfc9cdd07450e3f5