### PR TITLE
add requires-python metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors=[
 ]
 description="Self-service finite-state machines for the programmer on the go."
 readme="README.md"
+requires-python=">= 3.8"
 dependencies=[
   'typing_extensions; python_version<"3.10"',
 ]


### PR DESCRIPTION
Document the lack of support for Python 2 (and Python <3.8 in general) in a way that tools such as pip are aware.

https://packaging.python.org/en/latest/guides/dropping-older-python-versions/

Noticed this when the last remaining Python 2.7 test environment for pytest-twisted started failing this morning after the release of py3-only Automat 24.8.0.
https://github.com/pytest-dev/pytest-twisted/actions/runs/10438241303/job/28912571637

A "real" fix for this will require an updated release and a yank of 24.8.0.  Let me know if this is happening or not.  If not, I'll add a constraint to the pytest-twisted CI.