### PR TITLE
Allow return type annotations in output methods

### DIFF
--- a/src/automat/_methodical.py
+++ b/src/automat/_methodical.py
@@ -60,6 +60,10 @@ def _getArgNames(spec):
 
     The name of * and ** arguments is normalized to "*args" and "**kwargs".
 
+    Return type annotations are omitted, since we don't constrain input methods
+    to have the same return type as output methods, nor output methods to have
+    the same output type.
+
     :param ArgSpec spec: A function to interrogate for a signature.
     :return: The set of all argument names in `func`s signature.
     :rtype: Set[str]
@@ -69,7 +73,7 @@ def _getArgNames(spec):
         + spec.kwonlyargs
         + (("*args",) if spec.varargs else ())
         + (("**kwargs",) if spec.varkw else ())
-        + spec.annotations
+        + tuple(a for a in spec.annotations if a[0] != "return")
     )
 
 

--- a/src/automat/_test/test_methodical.py
+++ b/src/automat/_test/test_methodical.py
@@ -704,6 +704,31 @@ class MethodicalTests(TestCase):
             },
         )
 
+    def test_allowBasicTypeAnnotations(self):
+        """
+        L{MethodicalMachine} can operate with type annotations on inputs and outputs.
+        """
+
+        class Mechanism(object):
+            m = MethodicalMachine()
+
+            @m.input()
+            def an_input(self, arg: int):
+                "An input"
+
+            @m.output()
+            def an_output(self, arg: int) -> int:
+                return arg + 1
+
+            @m.state(initial=True)
+            def state(self):
+                "A state"
+
+            state.upon(an_input, enter=state, outputs=[an_output])
+
+        mechanism = Mechanism()
+        assert mechanism.an_input(2) == [3]
+
 
 # FIXME: error for wrong types on any call to _oneTransition
 # FIXME: better public API for .upon; maybe a context manager?


### PR DESCRIPTION
Output methods in `MethodicalMachine` might want a return type annotation. In `trunk` this blows up, because the signature doesn't match that of the input function. This adds a test and fixes it.