### PR TITLE
try upgrading github actions after all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,9 @@ jobs:
             TOX_ENV: "lint"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install graphviz


### PR DESCRIPTION
since I didn't notice https://github.com/glyph/automat/pull/171 until it was closed, let's do this here. (why isn't dependabot doing it I wonder?)

This commit was sponsored by genehack, Devin Prater, Guido Appenzeller, and my other patrons.  If you want to join them, you can support my work at https://glyph.im/patrons/.