### PR TITLE
Add optional error state functionality

### DIFF
--- a/src/automat/_core.py
+++ b/src/automat/_core.py
@@ -54,14 +54,20 @@ class Automaton(Generic[State, Input, Output]):
     Note that this is not the machine itself; it is immutable.
     """
 
-    def __init__(self, initial: State | None = None) -> None:
+    def __init__(
+        self, initial: State | None = None, error: State | None = None
+    ) -> None:
         """
         Initialize the set of transitions and the initial state.
         """
         if initial is None:
             initial = _NO_STATE  # type:ignore[assignment]
         assert initial is not None
+        if error is None:
+            error = _NO_STATE  # type:ignore[assignment]
+        assert error is not None
         self._initialState: State = initial
+        self._errorState: State = error
         self._transitions: set[tuple[State, Input, State, Sequence[Output]]] = set()
         self._unhandledTransition: Optional[tuple[State, Sequence[Output]]] = None
 
@@ -85,6 +91,24 @@ class Automaton(Generic[State, Input, Output]):
             )
 
         self._initialState = state
+
+    @property
+    def errorState(self) -> State:
+        """
+        Return this automaton's error state.
+        """
+        return self._errorState
+
+    @errorState.setter
+    def errorState(self, state: State) -> None:
+        """
+        Set this automaton's error state. Raises a ValueError if
+        this automaton already has an error state.
+        """
+        if self._errorState is not _NO_STATE:
+            raise ValueError("error state already set to {}".format(self._errorState))
+
+        self._errorState = state
 
     def addTransition(
         self,
@@ -201,3 +225,13 @@ class Transitioner(Generic[State, Input, Output]):
             outTracer = self._tracer(self._state, inputSymbol, outState)
         self._state = outState
         return (outputSymbols, outTracer)
+
+    def handleError(self, inputError: BaseException) -> None:
+        """
+        Put state machine into explicit error state.
+        """
+        # FIXME: Add support for transition outputs to error state
+        # if self._automaton.errorState not in self._automaton.states():
+        #     raise ValueError("No error state defined")
+        if self._automaton.errorState is not _NO_STATE:
+            self._state = self._automaton.errorState

--- a/src/automat/_test/test_output_exceptions.py
+++ b/src/automat/_test/test_output_exceptions.py
@@ -1,0 +1,131 @@
+"""
+Tests demonstrating behavior when user-defined output methods raise exceptions.
+"""
+
+import dataclasses
+from typing import Callable, Protocol
+from unittest import TestCase
+
+from automat import NoTransition
+
+from .. import TypeMachineBuilder, pep614
+
+
+class SimpleController(Protocol):
+    def trigger(self) -> None:
+        "Trigger a transition"
+
+    def recover(self) -> str:
+        "Recover from error state"
+
+    def get_state(self) -> str:
+        "Get current state"
+
+
+class OutputTransitions:
+    def process(self, value: int) -> int:
+        "Process a value"
+        return 0
+
+
+@dataclasses.dataclass
+class SimpleMachine:
+    outputs: OutputTransitions
+
+
+class OutputExceptionTests(TestCase):
+    def setUp(self):
+        self.builder = TypeMachineBuilder(SimpleController, SimpleMachine)
+
+        def problematic_data_provider(
+            inputs: SimpleController, core: SimpleMachine
+        ) -> int:
+            raise RuntimeError("Data factory failed!")
+            return 0
+
+        # Define three states
+        self.start = self.builder.state("start")
+        self.fallback = self.builder.error_state("fallback")
+        self.recovered = self.builder.state("recovered")
+        self.state_expecting_data = self.builder.state(
+            "state_expecting_data", problematic_data_provider
+        )
+
+        # State observers
+        self.start.upon(SimpleController.get_state).loop().returns("start")
+        self.fallback.upon(SimpleController.get_state).loop().returns("fallback")
+        self.recovered.upon(SimpleController.get_state).loop().returns("recovered")
+        self.state_expecting_data.upon(SimpleController.get_state).loop().returns(
+            "state_expecting_data"
+        )
+
+    def test_exception_in_output_propagates_to_caller(self):
+        @pep614(self.start.upon(SimpleController.trigger).loop())
+        def failing_output(machine: SimpleController, core: SimpleMachine) -> None:
+            raise ValueError("Output failed!")
+
+        machineFactory = self.builder.build()
+        machine = machineFactory(SimpleMachine(OutputTransitions()))
+
+        with self.assertRaises(ValueError) as cm:
+            machine.trigger()
+        self.assertEqual(str(cm.exception), "Output failed!")
+        with self.assertRaises(NoTransition) as cm:
+            machine.recover()
+        self.assertEqual(
+            str(cm.exception),
+            "no transition for recover in TypedState(name='fallback')",
+        )
+        self.assertEqual(machine.get_state(), "fallback")
+        with self.assertRaises(NoTransition) as cm:
+            machine.trigger()
+        self.assertEqual(
+            str(cm.exception),
+            "no transition for trigger in TypedState(name='fallback')",
+        )
+        self.assertEqual(machine.get_state(), "fallback")
+
+    def test_can_recover_from_error_state(self):
+        # Transition that fails
+        @pep614(self.start.upon(SimpleController.trigger).loop())
+        def failing_output(machine: SimpleController, core: SimpleMachine) -> None:
+            raise ValueError("Output failed!")
+
+        # Recovery transition
+        self.fallback.upon(SimpleController.recover).to(self.recovered).returns(
+            "success"
+        )
+        machineFactory = self.builder.build()
+        machine = machineFactory(SimpleMachine(OutputTransitions()))
+
+        self.assertEqual(machine.get_state(), "start")
+        with self.assertRaises(ValueError):
+            machine.trigger()
+        self.assertEqual(machine.get_state(), "fallback")
+        with self.assertRaises(NoTransition) as cm:
+            machine.trigger()
+        result = machine.recover()
+        self.assertEqual(result, "success")
+        self.assertEqual(machine.get_state(), "recovered")
+
+    def test_can_recover_from_data_factory_error(self):
+        # Transition to data state
+        self.start.upon(SimpleController.trigger).to(self.state_expecting_data).returns(
+            None
+        )
+        self.fallback.upon(SimpleController.recover).to(self.recovered).returns(
+            "success"
+        )
+        machineFactory = self.builder.build()
+        machine = machineFactory(SimpleMachine(OutputTransitions()))
+
+        self.assertEqual(machine.get_state(), "start")
+        with self.assertRaises(RuntimeError) as cm:
+            machine.trigger()
+        self.assertEqual(machine.get_state(), "fallback")
+        with self.assertRaises(NoTransition) as cm:
+            machine.trigger()
+
+        result = machine.recover()
+        self.assertEqual(result, "success")
+        self.assertEqual(machine.get_state(), "recovered")

--- a/src/automat/_typed.py
+++ b/src/automat/_typed.py
@@ -426,6 +426,9 @@ def implementMethod(
                 # run reentrant outputs.  not clear that state-teardown outputs are
                 # necessary
                 result = output(self, dataAtStart, *args, **kwargs)
+        except BaseException as ex:
+            transitioner.handleError(ex)
+            raise
         finally:
             self.__automat_postponed__ = None
         while postponed:
@@ -696,6 +699,11 @@ class TypeMachineBuilder(Generic[InputProtocol, Core]):
         else:
             assert not self._initial, "initial state cannot require state-specific data"
             return TypedDataState(name, self, dataFactory)
+
+    def error_state(self, name: str) -> TypedState[InputProtocol, Core]:
+        state = self.state(name=name)
+        self._automaton.errorState = state
+        return state
 
     def build(self) -> TypeMachine[InputProtocol, Core]:
         """


### PR DESCRIPTION
This is a branch I wrote for fun that tries to address issue #160

A few design questions I had while implementing:

1. Should the error state always be optional or should we create a minimal error state if the user does not create one?
2. Should we attempt to treat transitions into the error state as "real" transitions with transition outputs, _tracer calls, etc? This is often desirable for safety reasons in state machine design but I think I'd have to dig in a bit more to implement this correctly.
3. Should we attempt to provide the exception itself as an input to the error state?