### PR TITLE
update tutorial to fix the pushButton(remoteID) example

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -197,7 +197,7 @@ Obviously, mypy will also complain that our test callers are missing the
 ``remoteID`` argument as well, so if we change them to pass along some value
 like so:
 
-.. literalinclude:: examples/garage_door.py
+.. literalinclude:: examples/garage_door_security.py
    :start-after: do open
    :end-before: end open
 


### PR DESCRIPTION
In the tutorial, in the "Taking, Storing, and Returning Data" section, we add a `remoteID` argument to the `pushButton()` input method. The text explains that you must change the caller to include an argument, and then shows an example what the new caller should be doing.

```
Obviously, mypy will also complain that our test callers are missing the
``remoteID`` argument as well, so if we change them to pass along some value
like so:

.. literalinclude:: examples/garage_door.py
   :start-after: do open
   :end-before: end open
```

But, the example is pulled from the same unmodified `examples/garage_door.py` as the previous section, which lacks the extra argument, so what gets rendered is missing the argument:

<img width="822" height="160" alt="Image" src="https://github.com/user-attachments/assets/7af7b6be-df94-4139-9b80-2d76d1f25a80" />

This should update the docs to pull from the other example file, which includes the argument.